### PR TITLE
iManage Work connector: workspaces, folders and documents with mirrored security

### DIFF
--- a/docs/src/content/docs/connectors/imanage.md
+++ b/docs/src/content/docs/connectors/imanage.md
@@ -1,0 +1,126 @@
+---
+title: iManage Work
+description: Index workspaces, folders and documents from iManage Work, scoped by matter, with workspace, folder and document security mirrored.
+---
+
+The iManage Work connector indexes **workspaces, folders and documents** from an
+iManage estate, mirroring the security a firm has already set. A matter walled
+away from the authorizing account is never listed, so it is never indexed.
+
+| | |
+| --- | --- |
+| Syncs | Workspaces and folders (as containers), documents, document deletions |
+| Incremental | Per-library `edit_date` search, plus a workspace-security diff |
+| Scoping | Library, then workspace (the matter) |
+| Permission mirror | Yes, including iManage's own inherit/override distinction |
+| Token type | Refresh token |
+| Host | `cloudimanage.com` by default; per-connection override via the `api_base_url` field |
+
+:::caution[Not yet offered in the admin UI]
+This connector is built and tested against recorded payloads, but it has not yet
+run against a live tenant. The API operations and the security payload schema
+come from a published definition; the native REST **paths** are partly inferred.
+It stays out of the connectable catalog until one live sync confirms them. See
+[What is verified](#what-is-verified).
+:::
+
+## Getting a tenant
+
+There is no self-service route. Unlike most connectors here, you cannot sign up
+and start building — registering an application requires an existing iManage
+environment, and the API reference itself sits behind an iManage account.
+
+In practice that means one of:
+
+- **the firm's own tenant**, which is the normal case in production;
+- **a firm's sandbox tenant**, which iManage Cloud customers run alongside
+  production and can grant access to. This is the fastest route to a working
+  build;
+- **the iManage Technology Partner programme**, which is a sales-qualified
+  contact form rather than a signup.
+
+## Register the application
+
+In **iManage Control Center → Applications**, signed in as a member of the
+`NRTADMIN` group or with a role carrying Tier 2 Control Center privileges. No
+other role can register an application.
+
+1. **Add an application manually.** It is a third-party application that reaches
+   iManage Work through the API only, so it needs no UI extension package.
+2. **Redirect URI:** enter the appliance's callback exactly as shown in the
+   setup modal.
+3. **Keep it read-only.** This appliance mirrors security; it must never be able
+   to change it.
+4. **Credentials:** the application's configuration shows the **API Key** and
+   **API Secret**. *Auto-Generate* creates the secret if you do not supply one —
+   copy it then, it is not shown again.
+
+## Connect
+
+Enter the API key and secret, then authorize with a **dedicated account whose
+workspace access is exactly what the firm wants searchable**. The connection can
+never see more than that account.
+
+The **customer id** every API path is scoped by is read from the authorizing
+account at connect time; set it explicitly only where that lookup is not
+available.
+
+After authorization, pick libraries and then workspaces in the scope picker. Two
+levels, because an estate has a handful of libraries and thousands of matters,
+and a flat list of every matter is a picker nobody can use.
+
+## Permissions
+
+iManage states security as a `default_security` value plus an `acl` of trustees,
+each carrying an access level.
+
+- `read`, `read_write`, `full_access` and `change_security` confer read and
+  become viewers. **`no_access` is the explicit denial an ethical wall is built
+  from** and is never inverted into a grant. Anything unrecognised confers
+  nothing.
+- `public` means library-wide, which on this single-firm appliance is every
+  authenticated user.
+- Groups are expanded to their members, so a grant matches a real caller.
+- A user trustee carries an iManage login id, not an address. Where the payload
+  has an address it is used; otherwise the id lands in the `user:id:` namespace
+  the identity layer reconciles, rather than being dropped or guessed at.
+
+**What makes iManage easier than NetDocuments here:** iManage says on every
+object whether it *inherits* its container's security. Inheritance is therefore
+the source's own answer rather than a guess, so:
+
+- an **inheriting** document takes its container's mirrored access, at no extra
+  API call;
+- an **overriding** document is read on its own, one call for that document only;
+- an override that **cannot** be read stays fail-closed. It never falls back to
+  the container, because an override generally exists in order to be narrower.
+
+The same applies to folders: a restricted subfolder inside an open matter keeps
+its own audience rather than being flattened to the workspace's.
+
+## Incremental sync
+
+No delta feed exists, so an incremental run does two things:
+
+- searches each synced library for documents **edited since** the last
+  watermark, which finds edits and additions; and
+- re-reads each workspace's **security and diffs it** against the previous run.
+  A firm walls a matter by re-securing the workspace, and no document's
+  `edit_date` moves when that happens. A workspace whose security changed
+  re-emits its documents.
+
+Deletions have no tombstone and are reconciled from the previous run's
+per-workspace ids. An **empty or unreadable workspace listing is never treated
+as deletion** — it asks for a full sync instead.
+
+## What is verified
+
+| | |
+| --- | --- |
+| Operations, and the security payload schema | **Verified** — the published definition declares the ACL schema in full |
+| Access levels and `default_security` values | **Verified** — enumerated in that schema |
+| Document, folder and workspace profile fields | **Verified** — declared schemas |
+| `folders` / `subfolders` path shape | **Verified** — matches published third-party integration docs |
+| `/security`, `/documents/search`, `/groups/{id}/members` paths | **Inferred** — the published definition describes a facade, not the native REST paths |
+| `X-Auth-Token` header, OAuth endpoints | **Inferred** |
+| Live tenant sync | **Not run** |

--- a/src/knowledge_index/connectors/acl.py
+++ b/src/knowledge_index/connectors/acl.py
@@ -206,6 +206,93 @@ def box_collaborations_to_access(entries: list[dict[str, Any]] | None) -> Access
     return AccessControl(viewers=sorted(set(viewers)), is_public=False)
 
 
+# ----------------------------------------------------------------------- iManage Work
+
+# iManage access levels that confer read. ``no_access`` is the explicit denial an
+# ethical wall is built from and must never be read as a grant; anything unrecognised
+# is treated the same way, because guessing permissively is what publishes a walled
+# matter.
+IMANAGE_READ_LEVELS = frozenset({"read", "read_write", "full_access", "change_security"})
+
+# iManage's ``default_security`` on a document, folder or workspace. ``inherit`` means
+# the object genuinely takes its container's access, which is the one case where
+# inheritance is the source's own answer rather than this connector's guess.
+IMANAGE_INHERIT = "inherit"
+IMANAGE_PUBLIC = "public"
+
+
+def imanage_trustee_principal(entry: dict[str, Any]) -> str | None:
+    """Resolve one iManage ACL entry to a principal.
+
+    A user entry carries an iManage login id rather than an address, and nobody
+    authenticates to this appliance as ``JSCHMIDT``. An email-shaped value is preferred
+    where the payload has one; otherwise the id is emitted in the ``user:id:`` namespace
+    that :mod:`knowledge_index.connectors.principals` reconciles, the same fallback
+    Graph uses for a directory GUID.
+    """
+    kind = _clean(entry.get("type"))
+    identifier = _clean(entry.get("id"))
+    if kind == "group":
+        return f"group:imanage:{identifier}" if identifier else None
+    if kind != "user":
+        return None
+    for key in ("email", "name", "id"):
+        value = _clean(entry.get(key))
+        if value and "@" in value:
+            return f"user:{value}"
+    return f"user:id:{identifier}" if identifier else None
+
+
+def imanage_security_to_access(
+    security: dict[str, Any] | None,
+    *,
+    container_access: AccessControl | None = None,
+) -> AccessControl | None:
+    """Translate an iManage ``default_security`` plus ``acl`` payload.
+
+    Three cases, and the distinction between them is the source's own, not a heuristic:
+
+    ``inherit``  the object takes its container's access. This is the one inheritance
+                 iManage actually asserts, so it is honoured — passing the container's
+                 mirrored access straight through. ``None`` container access stays
+                 ``None``: unknown does not become inherited.
+    ``public``   readable by everyone in the library, which on this single-firm
+                 appliance is every authenticated user.
+    otherwise    the ACL is the answer, filtered to the levels that confer read.
+
+    Returns ``None`` when no payload could be read at all, keeping the object
+    fail-closed rather than asserting that nobody may see it.
+    """
+    if security is None:
+        return None
+    default_security = _clean(security.get("default_security"))
+    entries = security.get("acl")
+
+    if default_security == IMANAGE_INHERIT and not entries:
+        return container_access
+
+    viewers: list[str] = []
+    for entry in entries or []:
+        if _clean(entry.get("access_level")) not in IMANAGE_READ_LEVELS:
+            continue
+        principal = imanage_trustee_principal(entry)
+        if principal:
+            viewers.append(principal)
+
+    if default_security == IMANAGE_PUBLIC:
+        # Library-wide inside the firm's own tenant: everyone who can authenticate
+        # here. Named trustees are kept alongside so a later narrowing of the default
+        # does not silently drop them.
+        return AccessControl(viewers=sorted(set(viewers)), is_public=True)
+
+    if not viewers and default_security == IMANAGE_INHERIT:
+        return container_access
+    if not viewers and not default_security:
+        # Neither a default nor a usable ACL: nothing was actually read.
+        return None
+    return AccessControl(viewers=sorted(set(viewers)), is_public=False)
+
+
 # ------------------------------------------------------------------------- Confluence
 
 

--- a/src/knowledge_index/connectors/configs.py
+++ b/src/knowledge_index/connectors/configs.py
@@ -73,6 +73,64 @@ class ClioConfig(SourceConfig):
     )
 
 
+class IManageConfig(SourceConfig):
+    """iManage Work configuration schema."""
+
+    api_base_url: str = Field(
+        default="https://cloudimanage.com",
+        title="iManage host",
+        description=(
+            "The firm's iManage Work host. iManage Cloud tenants use "
+            "https://cloudimanage.com; a firm on its own infrastructure or in a "
+            "regional cloud has its own hostname. No trailing path — the connector "
+            "appends /work/api/v2 itself."
+        ),
+    )
+
+    @field_validator("api_base_url")
+    @classmethod
+    def validate_api_base_url_ssrf(cls, v: str) -> str:
+        """Validate the host for SSRF safety."""
+        validate_url(v.strip())
+        return v.strip().rstrip("/")
+
+    customer_id: str = Field(
+        default="",
+        title="Customer ID",
+        description=(
+            "The firm's iManage customer id, which every API path is scoped by. Leave "
+            "blank to read it from the authorizing account at connect time; set it "
+            "only where that lookup is not available."
+        ),
+    )
+
+    mirror_permissions: bool = Field(
+        default=True,
+        title="Mirror iManage Security",
+        description=(
+            "Mirror workspace, folder and document security so content is retrievable "
+            "only by the users and groups that hold read access in iManage, with "
+            "groups expanded to their members. When false, access is left unknown and "
+            "nothing is retrievable until an administrator grants it at the project "
+            "level."
+        ),
+    )
+
+    read_document_security: bool = Field(
+        default=True,
+        title="Read per-document security where it differs",
+        description=(
+            "iManage states on each document whether it inherits its container's "
+            "security or overrides it. When a document overrides, this reads that "
+            "document's own access list — one extra API call for that document only, "
+            "not for the whole estate. Turning this off makes an overriding document "
+            "fail-closed instead, which is safe but hides it; it never falls back to "
+            "the container, because an override usually exists in order to be "
+            "narrower."
+        ),
+    )
+
+
 class ConfluenceConfig(SourceConfig):
     """Confluence configuration schema."""
 

--- a/src/knowledge_index/connectors/cursors/imanage.py
+++ b/src/knowledge_index/connectors/cursors/imanage.py
@@ -1,0 +1,86 @@
+"""iManage Work cursor schema.
+
+iManage has no delta token either. What it has is a workspace and document search that
+filters on ``edit_date``, so an incremental run asks each synced library for documents
+edited since the last watermark.
+
+Security is the other half. A firm walls a matter by changing the *workspace's*
+security, and no document's ``edit_date`` moves when that happens. The mirrored access
+per workspace is kept here and diffed on every incremental run, so a re-secured
+workspace re-emits its documents at the policy interval rather than waiting for the
+periodic full scan.
+"""
+
+from datetime import UTC, datetime
+
+from pydantic import Field
+
+from ._base import BaseCursor
+
+
+class IManageCursor(BaseCursor):
+    """iManage Work incremental sync cursor."""
+
+    edited_since: str = Field(
+        default="",
+        description="ISO 8601 watermark: fetch documents edited after this instant.",
+    )
+
+    full_sync_required: bool = Field(
+        default=True,
+        description="Whether a full sync is required.",
+    )
+
+    last_full_sync_timestamp: str = Field(
+        default="",
+        description="ISO 8601 timestamp of last full sync.",
+    )
+
+    last_entity_changes_count: int = Field(
+        default=0,
+        description="Number of changes processed in the last incremental sync.",
+    )
+
+    tracked_groups: dict = Field(
+        default_factory=dict,
+        description=(
+            "Groups that held read access on the last run, id -> library. Recorded for "
+            "operators reading a sync's state; the next run rebuilds the set from the "
+            "workspaces it reads rather than restoring this one, so a group whose "
+            "access the firm has revoked stops being expanded."
+        ),
+    )
+
+    workspace_acls: dict = Field(
+        default_factory=dict,
+        description=(
+            "Snapshot of workspace_id -> sorted viewer principals. Diffed on every "
+            "incremental run: a workspace whose security changed re-emits its "
+            "documents, because re-securing a matter moves no document timestamp."
+        ),
+    )
+
+    workspace_documents: dict = Field(
+        default_factory=dict,
+        description=(
+            "Snapshot of workspace_id -> [document ids]. A document removed from a "
+            "workspace has no tombstone in the search API, so this snapshot is the "
+            "only place its id still exists on this side."
+        ),
+    )
+
+    def needs_full_sync(self) -> bool:
+        if self.full_sync_required:
+            return True
+        return not self.edited_since
+
+    def needs_periodic_full_sync(self, interval_days: int = 7) -> bool:
+        if not self.last_full_sync_timestamp:
+            return True
+        try:
+            last_full = datetime.fromisoformat(self.last_full_sync_timestamp)
+            if last_full.tzinfo is None:
+                last_full = last_full.replace(tzinfo=UTC)
+            return (datetime.now(UTC) - last_full).days >= interval_days
+        except (ValueError, TypeError):
+            return True

--- a/src/knowledge_index/connectors/entities/imanage.py
+++ b/src/knowledge_index/connectors/entities/imanage.py
@@ -1,0 +1,252 @@
+"""iManage Work entity schemas.
+
+An iManage estate nests library → workspace → folder → document. The workspace is the
+matter: for a law firm it is the unit a partner reasons about, and it is what gives a
+retrieved paragraph something citable to point at.
+
+Identifiers keep the source's own composite form — ``ACTIVE_US!4512345.1`` is library,
+document number and version in one string. They are carried whole rather than split,
+because that composite is what every later API call takes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import computed_field
+
+from knowledge_index.connectors.entities._base import (
+    BaseEntity,
+    Breadcrumb,
+    DeletionEntity,
+    FileEntity,
+)
+from knowledge_index.connectors.entities._field import IndexField
+
+
+class IManageWorkspaceEntity(BaseEntity):
+    """A workspace: in a law firm, the matter."""
+
+    workspace_id: str = IndexField(..., description="iManage workspace ID", is_entity_id=True)
+    name: str = IndexField(..., description="Workspace name", is_name=True, embeddable=True)
+    created_at: Optional[datetime] = IndexField(
+        None, description="When the workspace was created", is_created_at=True
+    )
+    updated_at: Optional[datetime] = IndexField(
+        None, description="When the workspace was last modified", is_updated_at=True
+    )
+
+    library_id: Optional[str] = IndexField(
+        None, description="Library the workspace lives in", embeddable=False
+    )
+    description: Optional[str] = IndexField(
+        None, description="Workspace description", embeddable=True
+    )
+    owner: Optional[str] = IndexField(None, description="Workspace owner", embeddable=True)
+    subclass: Optional[str] = IndexField(
+        None, description="Workspace subclass, often the practice area", embeddable=True
+    )
+    client_id: Optional[str] = IndexField(
+        None, description="Client from custom1, the firm's conventional client field",
+        embeddable=True,
+    )
+    matter_id: Optional[str] = IndexField(
+        None, description="Matter from custom2, the firm's conventional matter field",
+        embeddable=True,
+    )
+
+    @classmethod
+    def from_api(
+        cls, data: Dict[str, Any], *, library_id: str | None = None
+    ) -> Optional[IManageWorkspaceEntity]:
+        """Build from a workspace profile payload."""
+        identifier = data.get("id")
+        if not identifier:
+            return None
+        return cls(
+            workspace_id=str(identifier),
+            breadcrumbs=[],
+            name=str(data.get("name") or identifier),
+            library_id=library_id or data.get("database"),
+            description=data.get("description"),
+            owner=data.get("owner_description") or data.get("owner"),
+            subclass=data.get("subclass_description") or data.get("subclass"),
+            # custom1/custom2 are where firms conventionally put client and matter.
+            # The description variants carry the human-readable value.
+            client_id=data.get("custom1_description") or data.get("custom1"),
+            matter_id=data.get("custom2_description") or data.get("custom2"),
+            created_at=data.get("create_date"),
+            updated_at=data.get("edit_date"),
+        )
+
+
+class IManageFolderEntity(BaseEntity):
+    """A folder inside a workspace."""
+
+    folder_id: str = IndexField(..., description="iManage folder ID", is_entity_id=True)
+    name: str = IndexField(..., description="Folder name", is_name=True, embeddable=True)
+    created_at: Optional[datetime] = IndexField(
+        None, description="When the folder was created", is_created_at=True
+    )
+    updated_at: Optional[datetime] = IndexField(
+        None, description="When the folder was last modified", is_updated_at=True
+    )
+
+    library_id: Optional[str] = IndexField(
+        None, description="Library the folder lives in", embeddable=False
+    )
+    workspace_id: Optional[str] = IndexField(
+        None, description="Workspace the folder belongs to", embeddable=False
+    )
+    parent_id: Optional[str] = IndexField(None, description="Parent folder ID", embeddable=False)
+    description: Optional[str] = IndexField(
+        None, description="Folder description", embeddable=True
+    )
+    folder_type: Optional[str] = IndexField(
+        None, description="Folder type reported by iManage", embeddable=False
+    )
+    owner: Optional[str] = IndexField(None, description="Folder owner", embeddable=True)
+
+    @classmethod
+    def from_api(
+        cls,
+        data: Dict[str, Any],
+        *,
+        library_id: str | None = None,
+        breadcrumbs: List[Breadcrumb] | None = None,
+    ) -> Optional[IManageFolderEntity]:
+        """Build from a folder profile payload."""
+        identifier = data.get("id")
+        if not identifier:
+            return None
+        return cls(
+            folder_id=str(identifier),
+            breadcrumbs=breadcrumbs or [],
+            name=str(data.get("name") or identifier),
+            library_id=library_id or data.get("database"),
+            workspace_id=data.get("workspace_id"),
+            parent_id=data.get("parent_id"),
+            description=data.get("description"),
+            folder_type=data.get("folder_type"),
+            owner=data.get("owner_description") or data.get("owner"),
+            updated_at=data.get("edit_date"),
+        )
+
+
+class IManageDocumentEntity(FileEntity):
+    """A document: the only iManage object that carries bytes to index."""
+
+    document_id: str = IndexField(
+        ..., description="iManage document ID (library!number.version)", is_entity_id=True
+    )
+    name: str = IndexField(..., description="Document name", is_name=True, embeddable=True)
+    created_at: Optional[datetime] = IndexField(
+        None, description="When the document was created", is_created_at=True
+    )
+    updated_at: Optional[datetime] = IndexField(
+        None, description="When the document was last edited", is_updated_at=True
+    )
+
+    library_id: Optional[str] = IndexField(
+        None, description="Library the document lives in", embeddable=False
+    )
+    document_number: Optional[str] = IndexField(
+        None, description="iManage document number", embeddable=False
+    )
+    version: Optional[str] = IndexField(None, description="Version number", embeddable=False)
+    extension: Optional[str] = IndexField(None, description="File extension", embeddable=False)
+    workspace_id: Optional[str] = IndexField(
+        None, description="Workspace the document belongs to", embeddable=False
+    )
+    workspace_name: Optional[str] = IndexField(
+        None, description="Workspace name, the matter in a law firm", embeddable=True
+    )
+    folder_id: Optional[str] = IndexField(
+        None, description="Folder the document was found in", embeddable=False
+    )
+    author: Optional[str] = IndexField(None, description="Document author", embeddable=True)
+    operator: Optional[str] = IndexField(
+        None, description="Person who last operated on the document", embeddable=True
+    )
+    document_class: Optional[str] = IndexField(
+        None, description="iManage class, e.g. correspondence or pleading", embeddable=True
+    )
+    subclass: Optional[str] = IndexField(
+        None, description="iManage subclass", embeddable=True
+    )
+    is_declared_record: Optional[bool] = IndexField(
+        None, description="Whether the document is declared as a record", embeddable=False
+    )
+
+    @classmethod
+    def from_api(
+        cls,
+        data: Dict[str, Any],
+        *,
+        api_base_url: str,
+        customer_id: str,
+        library_id: str | None = None,
+        folder_id: str | None = None,
+        breadcrumbs: List[Breadcrumb] | None = None,
+    ) -> Optional[IManageDocumentEntity]:
+        """Build from a document profile payload.
+
+        Returns ``None`` for a payload with no id: a document that cannot be addressed
+        cannot be re-fetched or deleted later, so indexing it would create a row that
+        can never be corrected.
+        """
+        identifier = data.get("id")
+        if not identifier:
+            return None
+        document_id = str(identifier)
+        library = str(library_id or data.get("database") or document_id.partition("!")[0])
+        size = data.get("size")
+        extension = str(data.get("extension") or "").lstrip(".").lower()
+        return cls(
+            document_id=document_id,
+            breadcrumbs=breadcrumbs or [],
+            name=str(data.get("name") or data.get("full_file_name") or document_id),
+            url=(
+                f"{api_base_url}/work/api/v2/customers/{customer_id}/libraries/"
+                f"{library}/documents/{document_id}/download"
+            ),
+            size=int(size) if isinstance(size, (int, float)) or str(size or "").isdigit() else 0,
+            file_type=extension or "file",
+            mime_type=data.get("content_type"),
+            local_path=None,
+            library_id=library,
+            document_number=(
+                str(data["document_number"]) if data.get("document_number") is not None else None
+            ),
+            version=str(data["version"]) if data.get("version") is not None else None,
+            extension=extension or None,
+            workspace_id=data.get("workspace_id"),
+            workspace_name=data.get("workspace_name"),
+            folder_id=folder_id,
+            author=data.get("author_description") or data.get("author"),
+            operator=data.get("operator_description") or data.get("operator"),
+            document_class=data.get("class_description") or data.get("class"),
+            subclass=data.get("subclass_description") or data.get("subclass"),
+            is_declared_record=data.get("is_declared"),
+            created_at=data.get("create_date"),
+            updated_at=data.get("edit_date"),
+        )
+
+    @computed_field(return_type=str)
+    def web_url(self) -> str:
+        """Deep link a lawyer can open in iManage Work to see the document in context."""
+        return f"iwl://open?id={self.document_id}"
+
+
+class IManageDocumentDeletionEntity(DeletionEntity):
+    """A document that has left iManage, or left the synced scope."""
+
+    deletes_entity_class = IManageDocumentEntity
+
+    document_id: str = IndexField(
+        ...,
+        description="iManage document ID that was removed",
+        is_entity_id=True,
+        is_name=True,
+    )

--- a/src/knowledge_index/connectors/registry.py
+++ b/src/knowledge_index/connectors/registry.py
@@ -136,6 +136,28 @@ CATALOG: tuple[ConnectorSpec, ...] = (
         ),
     ),
     ConnectorSpec(
+        short_name="imanage",
+        label="iManage Work",
+        category="Legal DMS",
+        module=f"{SOURCES}.imanage",
+        class_name="IManageSource",
+        mirrors_acls=True,
+        incremental=True,
+        supports_scoping=True,
+        oauth_provider="imanage",
+        notes=(
+            "Indexes the workspaces the authorizing account can open — a matter walled "
+            "away from that account is never fetched. Mirrors workspace, folder and "
+            "document security, honouring iManage's own statement of whether an object "
+            "inherits: an inheriting document takes its container's audience, an "
+            "overriding one is read on its own, and an override that cannot be read "
+            "stays fail-closed rather than inheriting. no_access is treated as the "
+            "wall it is. Groups are expanded to their members. Incremental via a "
+            "per-library edited-since search plus a workspace-security diff, because "
+            "re-securing a matter moves no document timestamp."
+        ),
+    ),
+    ConnectorSpec(
         short_name="teams",
         label="Microsoft Teams",
         category="Messaging",
@@ -363,15 +385,6 @@ class PlannedConnector:
 
 
 PLANNED: tuple[PlannedConnector, ...] = (
-    PlannedConnector(
-        short_name="imanage",
-        label="iManage Work",
-        category="Legal DMS",
-        notes=(
-            "The dominant large-firm legal DMS. Planned: workspace and matter-file "
-            "sync with mirrored folder and document security."
-        ),
-    ),
     PlannedConnector(
         short_name="netdocuments",
         label="NetDocuments",

--- a/src/knowledge_index/connectors/runtime/providers.yaml
+++ b/src/knowledge_index/connectors/runtime/providers.yaml
@@ -452,3 +452,48 @@ providers:
       note: >-
         A bot token reads history only in channels the bot has joined. Invite it with
         /invite @<app name> in every public or private channel that should be indexed.
+
+  imanage:
+    oauth_type: with_refresh
+    # Host-relative: iManage Cloud tenants live at cloudimanage.com, a firm on its own
+    # infrastructure has its own hostname. Both endpoints follow the host set on the
+    # connection, so a self-hosted firm changes one field rather than needing its own
+    # provider entry.
+    authorize_url: https://cloudimanage.com/auth/oauth2/authorize
+    token_url: https://cloudimanage.com/auth/oauth2/token
+    # iManage issues an X-Auth-Token rather than a bearer, and takes the client
+    # credentials in the form body on the token call.
+    client_credential_location: body
+    # Read is the whole grant. iManage's write scopes would let this appliance change a
+    # firm's documents and their security; a shadow index needs neither.
+    scope: read
+    registration:
+      console: iManage Control Center
+      console_url: https://cloudimanage.com
+      create: >-
+        Control Center → Applications → Add an application manually. The signed-in user
+        must be a member of the NRTADMIN group, or hold a role with Tier 2 Control
+        Center privileges; no other role can register an application.
+      app_type: >-
+        Register it as a third-party application that accesses iManage Work through the
+        API only. It does not extend the iManage user interface, so it needs no UI
+        extension package.
+      redirect_field: >-
+        Enter the appliance's callback exactly as shown in the setup modal.
+      scope_label: Application scopes
+      scope_location: >-
+        Requested in the authorization URL; nothing to type. Keep the registered
+        application read-only — this appliance mirrors security, it must never be able
+        to change it.
+      secret: >-
+        The application's configuration shows the API Key and API Secret. "Auto-Generate"
+        creates the secret if the firm does not supply one; copy it then, it is not
+        shown again.
+      account: >-
+        Authorize with a dedicated account whose workspace access is exactly what the
+        firm wants searchable. Matters that account cannot open are never listed, so
+        they are never indexed.
+      note: >-
+        There is no self-service route to a tenant. Registering this application needs
+        an existing iManage environment — the firm's own, or a sandbox tenant they can
+        grant access to.

--- a/src/knowledge_index/connectors/sources/imanage.py
+++ b/src/knowledge_index/connectors/sources/imanage.py
@@ -1,0 +1,867 @@
+"""iManage Work source implementation using the Work API v2.
+
+Retrieves a firm's iManage estate:
+ - Workspaces (IManageWorkspaceEntity — in a law firm, the matter, and the sync root)
+ - Folders (IManageFolderEntity containers, giving documents their breadcrumb)
+ - Documents (IManageDocumentEntity files, staged for the fetch stage)
+
+Incremental sync:
+ - iManage has no delta feed. An incremental run searches each synced library for
+   documents edited since the watermark, which reports edits and additions.
+ - Security is the other half: a firm walls a matter by re-securing the *workspace*,
+   and no document's ``edit_date`` moves when that happens. Every incremental run
+   re-reads workspace security and diffs it against the cursor snapshot, so a
+   re-secured workspace re-emits its documents at the policy interval.
+ - Deletions have no tombstone; they are reconciled from the cursor's per-workspace id
+   snapshot, with the periodic full scan as backstop.
+
+Access graph generation:
+ - iManage states security as ``default_security`` plus an ``acl`` of trustees, each
+   with an access level. Only levels that confer read become viewers; ``no_access`` is
+   the explicit denial an ethical wall is built from and is never inverted into a grant.
+ - Crucially, iManage says on each object whether it *inherits*. That makes inheritance
+   the source's own answer rather than this connector's guess: an inheriting document
+   takes its container's mirrored access, and an overriding one is read on its own.
+   Where an override cannot be read the document stays fail-closed rather than falling
+   back to the container, because an override generally exists in order to be narrower.
+ - Groups are expanded to their members so a grant matches a real caller.
+
+Provenance and its limits: this connector was written against the iManage Work API
+definition Microsoft publishes for its certified Power Platform connector
+(microsoft/PowerPlatformConnectors, MIT). That definition is authoritative for the
+operations and — unusually and usefully — for the security payload's schema, which it
+declares in full. It describes Microsoft's own facade rather than the native REST
+paths, so the *paths* used here are the native Work API v2 ones and are partly
+inferred. Everything unverified is listed in the PR that introduced this file, and the
+connector stays out of the admin UI until one live tenant sync confirms it.
+"""
+
+from datetime import UTC, datetime
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
+from tenacity import retry, stop_after_attempt
+
+from knowledge_index.connectors.acl import (
+    IMANAGE_INHERIT,
+    imanage_security_to_access,
+)
+from knowledge_index.connectors.base import BaseSource
+from knowledge_index.connectors.configs import IManageConfig
+from knowledge_index.connectors.cursors.imanage import IManageCursor
+from knowledge_index.connectors.cursors.state import SyncCursor
+from knowledge_index.connectors.decorators import source
+from knowledge_index.connectors.entities._base import AccessControl, BaseEntity, Breadcrumb
+from knowledge_index.connectors.entities.imanage import (
+    IManageDocumentDeletionEntity,
+    IManageDocumentEntity,
+    IManageFolderEntity,
+    IManageWorkspaceEntity,
+)
+from knowledge_index.connectors.http_helpers import raise_for_status
+from knowledge_index.connectors.retry import (
+    retry_if_rate_limit_or_timeout,
+    wait_rate_limit_with_backoff,
+)
+from knowledge_index.connectors.runtime.errors import FileSkippedException, SourceAuthError
+from knowledge_index.connectors.runtime.files import FileService
+from knowledge_index.connectors.runtime.http import HttpClient
+from knowledge_index.connectors.runtime.logging import ContextualLogger
+from knowledge_index.connectors.runtime.tokens import TokenProviderProtocol
+from knowledge_index.connectors.runtime.types import (
+    AuthenticationMethod,
+    BrowseNode,
+    MembershipTuple,
+    NodeSelectionData,
+    OAuthType,
+    RateLimitLevel,
+)
+
+PAGE_LIMIT = 100
+MAX_FOLDER_DEPTH = 32
+
+# What the cursor stores for an object whose access could not be read. Distinct from an
+# empty list, which is a real answer ("these named trustees, nobody else"), and from a
+# public one. Without the distinction an unreadable workspace would look identical to a
+# genuinely empty one and the diff would miss the moment it became readable again.
+UNKNOWN_ACCESS = ["?unknown"]
+
+
+def _access_key(access: Optional[AccessControl]) -> List[str]:
+    """A comparable snapshot of one mirrored ACL.
+
+    ``is_public`` has to be part of it. Storing only ``viewers`` made a public
+    workspace's snapshot (empty list) differ from its own recomputed value on every
+    run, so every public matter re-synced its entire contents every time.
+    """
+    if access is None:
+        return list(UNKNOWN_ACCESS)
+    viewers = sorted(set(access.viewers or []))
+    if access.is_public:
+        viewers.append("role:authenticated")
+    return viewers
+
+
+def _access_from_key(key: Optional[List[str]]) -> Optional[AccessControl]:
+    """Rebuild a mirrored ACL from its snapshot, preserving unknown as unknown."""
+    if not key or key == UNKNOWN_ACCESS:
+        return None
+    viewers = [viewer for viewer in key if viewer != "role:authenticated"]
+    return AccessControl(viewers=viewers, is_public="role:authenticated" in key)
+
+
+@source(
+    name="iManage Work",
+    short_name="imanage",
+    auth_methods=[
+        AuthenticationMethod.OAUTH_BROWSER,
+        AuthenticationMethod.OAUTH_TOKEN,
+        AuthenticationMethod.AUTH_PROVIDER,
+    ],
+    oauth_type=OAuthType.WITH_REFRESH,
+    auth_config_class=None,
+    config_class=IManageConfig,
+    labels=["Legal DMS", "Legal"],
+    supports_continuous=True,
+    cursor_class=IManageCursor,
+    supports_access_control=True,
+    supports_browse_tree=True,
+    rate_limit_level=RateLimitLevel.ORG,
+)
+class IManageSource(BaseSource):
+    """iManage Work source connector: workspaces, folders and documents."""
+
+    # One security call per workspace plus one per referenced group. A firm has
+    # thousands of matters but a sync is normally scoped to a fraction of them, and
+    # membership freshness is what bounds how long a re-walled matter stays wrong.
+    cheap_memberships = True
+
+    _api_base_url: str
+    _customer_id: str
+    _mirror_permissions: bool
+    _read_document_security: bool
+    _tracked_groups: Dict[str, str]
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        auth: TokenProviderProtocol,
+        logger: ContextualLogger,
+        http_client: HttpClient,
+        config: IManageConfig,
+    ) -> "IManageSource":
+        """Create a new iManage source instance."""
+        instance = cls(auth=auth, logger=logger, http_client=http_client)
+        instance._api_base_url = config.api_base_url.rstrip("/")
+        instance._customer_id = str(config.customer_id or "").strip()
+        instance._mirror_permissions = config.mirror_permissions
+        instance._read_document_security = config.read_document_security
+        instance._tracked_groups = {}
+        return instance
+
+    @property
+    def _auth_hosts(self) -> Tuple[str, ...]:
+        """The only host the firm's bearer token may be sent to."""
+        return (urlparse(self._api_base_url).netloc,)
+
+    # --------------------------------------------------------------------------- http
+
+    @retry(
+        stop=stop_after_attempt(5),
+        retry=retry_if_rate_limit_or_timeout,
+        wait=wait_rate_limit_with_backoff,
+        reraise=True,
+    )
+    async def _get(self, url: str, params: Optional[Dict] = None) -> Any:
+        """Make an authenticated GET request to the iManage Work API.
+
+        A 403 or 404 becomes an empty body: an estate always contains workspaces the
+        authorizing account cannot open, and one closed door must not end the scan.
+        """
+        token = await self.auth.get_token()
+        headers = {"X-Auth-Token": token, "Accept": "application/json"}
+        response = await self.http_client.get(url, headers=headers, params=params)
+
+        if response.status_code == 401 and self.auth.supports_refresh:
+            self.logger.warning(f"Got 401 from iManage at {url}, refreshing token...")
+            new_token = await self.auth.force_refresh()
+            headers["X-Auth-Token"] = new_token
+            response = await self.http_client.get(url, headers=headers, params=params)
+
+        if response.status_code in (403, 404):
+            self.logger.warning(f"iManage {response.status_code} for {url}")
+            return {}
+
+        raise_for_status(
+            response,
+            source_short_name=self.short_name,
+            token_provider_kind=self.auth.provider_kind,
+        )
+        return response.json()
+
+    @property
+    def _api(self) -> str:
+        return f"{self._api_base_url}/work/api/v2"
+
+    def _customer_path(self, suffix: str) -> str:
+        return f"{self._api}/customers/{self._customer_id}{suffix}"
+
+    @staticmethod
+    def _payload(data: Any) -> Any:
+        """iManage wraps every response in ``data``; unwrap it, tolerating a bare body."""
+        if isinstance(data, dict) and "data" in data:
+            return data["data"]
+        return data
+
+    def _records(self, data: Any) -> List[Dict]:
+        payload = self._payload(data)
+        if isinstance(payload, list):
+            return [record for record in payload if isinstance(record, dict)]
+        if isinstance(payload, dict):
+            for key in ("results", "items", "documents", "folders", "workspaces"):
+                candidate = payload.get(key)
+                if isinstance(candidate, list):
+                    return [record for record in candidate if isinstance(record, dict)]
+        return []
+
+    async def _paginate(self, url: str, params: Optional[Dict] = None) -> AsyncGenerator[Dict, None]:
+        """Yield records from a list endpoint, walking iManage's offset paging."""
+        offset = 0
+        while True:
+            query = {**(params or {}), "limit": PAGE_LIMIT, "offset": offset}
+            data = await self._get(url, params=query)
+            records = self._records(data)
+            for record in records:
+                yield record
+            if len(records) < PAGE_LIMIT:
+                return
+            offset += PAGE_LIMIT
+
+    async def _resolve_customer_id(self) -> str:
+        """The customer id every path is scoped by, read from the account if not set."""
+        if self._customer_id:
+            return self._customer_id
+        data = await self._get(f"{self._api}/customers")
+        for record in self._records(data):
+            identifier = str(record.get("id") or "").strip()
+            if identifier:
+                self._customer_id = identifier
+                return identifier
+        raise SourceAuthError(
+            "iManage did not report a customer id for this account; set it explicitly "
+            "in the connection's settings"
+        )
+
+    # ------------------------------------------------------------------ access mirror
+
+    async def _security(
+        self,
+        *,
+        library_id: str,
+        object_type: str,
+        object_id: str,
+        container_access: Optional[AccessControl] = None,
+    ) -> Optional[AccessControl]:
+        """Read and mirror one object's security.
+
+        ``None`` when it could not be read: unknown, fail-closed, and reported as a
+        capability gap rather than published to the firm.
+        """
+        if not self._mirror_permissions:
+            return None
+        url = (
+            f"{self._customer_path(f'/libraries/{library_id}')}"
+            f"/{object_type}/{object_id}/security"
+        )
+        try:
+            data = await self._get(url)
+        except SourceAuthError:
+            raise
+        except Exception as e:
+            self.logger.warning(f"Could not read security for {object_type} {object_id}: {e}")
+            return None
+        payload = self._payload(data)
+        if not isinstance(payload, dict) or not payload:
+            return None
+        access = imanage_security_to_access(payload, container_access=container_access)
+        for entry in payload.get("acl") or []:
+            if str(entry.get("type") or "").strip().lower() == "group":
+                identifier = str(entry.get("id") or "").strip()
+                if identifier:
+                    self._tracked_groups[identifier] = library_id
+        return access
+
+    async def generate_access_control_memberships(
+        self,
+    ) -> AsyncGenerator[MembershipTuple, None]:
+        """Expand tracked iManage groups into user memberships.
+
+        Without these rows a grant to ``group:imanage:{id}`` matches no caller and a
+        walled matter is invisible rather than protected.
+        """
+        if not self._mirror_permissions or not self._tracked_groups:
+            return
+        self.logger.info(f"Expanding {len(self._tracked_groups)} iManage groups")
+        for group_id, library_id in sorted(self._tracked_groups.items()):
+            url = f"{self._customer_path(f'/libraries/{library_id}')}/groups/{group_id}/members"
+            try:
+                data = await self._get(url)
+            except SourceAuthError:
+                raise
+            except Exception as e:
+                # Fail-closed: an unexpandable group grants nobody, and a later healthy
+                # run restores its members.
+                self.logger.warning(f"Could not expand iManage group {group_id}: {e}")
+                continue
+            for member in self._records(data):
+                email = str(member.get("email") or "").strip().lower()
+                if not email or "@" not in email:
+                    continue
+                yield MembershipTuple(
+                    member_id=email,
+                    member_type="user",
+                    group_id=f"imanage:{group_id.casefold()}",
+                    group_name=str(member.get("group_name") or group_id),
+                )
+
+    # ------------------------------------------------------------------------- crawl
+
+    @staticmethod
+    def _selected_workspaces(
+        node_selections: Optional[List[NodeSelectionData]],
+    ) -> List[Tuple[str, str]]:
+        """The (library, workspace) pairs this connection was scoped to."""
+        selected: List[Tuple[str, str]] = []
+        for selection in node_selections or []:
+            metadata = selection.node_metadata or {}
+            workspace_id = str(
+                metadata.get("workspace_id") or selection.source_node_id or ""
+            ).strip()
+            library_id = str(metadata.get("library_id") or "").strip()
+            if not library_id and "!" in workspace_id:
+                library_id = workspace_id.partition("!")[0]
+            if workspace_id and (library_id, workspace_id) not in selected:
+                selected.append((library_id, workspace_id))
+        return selected
+
+    async def _libraries(self) -> List[str]:
+        data = await self._get(self._customer_path("/libraries"))
+        return [
+            str(record["id"]) for record in self._records(data) if record.get("id")
+        ]
+
+    async def _workspaces(self, library_id: str) -> AsyncGenerator[Dict, None]:
+        url = self._customer_path(f"/libraries/{library_id}/workspaces")
+        async for record in self._paginate(url):
+            yield record
+
+    async def _walk_folder(
+        self,
+        folder_id: str,
+        *,
+        library_id: str,
+        workspace_id: str,
+        container_access: Optional[AccessControl],
+        breadcrumbs: List[Breadcrumb],
+        files: FileService | None,
+        seen: set[str],
+        document_ids: List[str],
+        depth: int = 0,
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Walk a folder's subfolders and documents depth-first."""
+        if folder_id in seen or depth > MAX_FOLDER_DEPTH:
+            return
+        seen.add(folder_id)
+
+        base = self._customer_path(f"/libraries/{library_id}/folders/{folder_id}")
+
+        async for record in self._paginate(f"{base}/subfolders"):
+            identifier = str(record.get("id") or "").strip()
+            if not identifier or identifier in seen:
+                continue
+            folder = IManageFolderEntity.from_api(
+                record, library_id=library_id, breadcrumbs=breadcrumbs
+            )
+            if folder is None:
+                continue
+            # A folder states its own security exactly as a document does, so a
+            # restricted subfolder inside an open matter is honoured rather than
+            # flattened to the workspace's audience.
+            folder_access = await self._security(
+                library_id=library_id,
+                object_type="folders",
+                object_id=identifier,
+                container_access=container_access,
+            )
+            folder.access = folder_access
+            yield folder
+
+            child_breadcrumbs = [
+                *breadcrumbs,
+                Breadcrumb(
+                    entity_id=folder.folder_id,
+                    name=folder.name,
+                    entity_type="IManageFolderEntity",
+                ),
+            ]
+            async for entity in self._walk_folder(
+                identifier,
+                library_id=library_id,
+                workspace_id=workspace_id,
+                container_access=folder_access,
+                breadcrumbs=child_breadcrumbs,
+                files=files,
+                seen=seen,
+                document_ids=document_ids,
+                depth=depth + 1,
+            ):
+                yield entity
+
+        async for record in self._paginate(f"{base}/documents"):
+            entity = await self._document_entity(
+                record,
+                library_id=library_id,
+                folder_id=folder_id,
+                container_access=container_access,
+                breadcrumbs=breadcrumbs,
+                files=files,
+            )
+            if entity is not None:
+                document_ids.append(entity.document_id)
+                yield entity
+
+    async def _document_access(
+        self, record: Dict, library_id: str, container_access: Optional[AccessControl]
+    ) -> Optional[AccessControl]:
+        """The mirrored ACL for one document.
+
+        iManage states whether the document inherits. That is the source's own answer,
+        so an inheriting document takes its container's access without a second call.
+        An overriding document is read on its own; if that read is switched off or
+        fails, it stays fail-closed rather than inheriting, because an override
+        generally exists in order to be narrower than the container.
+        """
+        if not self._mirror_permissions:
+            return None
+        default_security = str(record.get("default_security") or "").strip().lower()
+        if default_security == IMANAGE_INHERIT:
+            return container_access
+        if not self._read_document_security:
+            return None
+        identifier = str(record.get("id") or "").strip()
+        if not identifier:
+            return None
+        return await self._security(
+            library_id=library_id,
+            object_type="documents",
+            object_id=identifier,
+            container_access=container_access,
+        )
+
+    async def _document_entity(
+        self,
+        record: Dict,
+        *,
+        library_id: str,
+        folder_id: Optional[str],
+        container_access: Optional[AccessControl],
+        breadcrumbs: List[Breadcrumb],
+        files: FileService | None,
+    ) -> Optional[IManageDocumentEntity]:
+        """Build one document entity, mirror its access, and stage its bytes."""
+        entity = IManageDocumentEntity.from_api(
+            record,
+            api_base_url=self._api_base_url,
+            customer_id=self._customer_id,
+            library_id=library_id,
+            folder_id=folder_id,
+            breadcrumbs=breadcrumbs,
+        )
+        if entity is None:
+            return None
+        entity.access = await self._document_access(record, library_id, container_access)
+
+        if files:
+            try:
+                await files.download_from_url(
+                    entity=entity,
+                    client=self.http_client,
+                    auth=self.auth,
+                    logger=self.logger,
+                    auth_hosts=self._auth_hosts,
+                )
+                if not entity.local_path:
+                    self.logger.warning(f"Download produced no local path for {entity.name}")
+                    return None
+            except FileSkippedException as e:
+                self.logger.debug(f"Skipping document {entity.name}: {e.reason}")
+                return None
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 401:
+                    raise
+                self.logger.warning(
+                    f"HTTP {e.response.status_code} downloading {entity.name}: {e}"
+                )
+                return None
+        return entity
+
+    # -------------------------------------------------------------------------- sync
+
+    def _should_do_full_sync(self, cursor: SyncCursor | None) -> Tuple[bool, str]:
+        cursor_data = cursor.data if cursor else {}
+        if not cursor_data:
+            return True, "no cursor data (first sync)"
+        schema = IManageCursor(**cursor_data)
+        if schema.needs_full_sync():
+            return True, "full_sync_required flag set or no watermark"
+        if schema.needs_periodic_full_sync():
+            return True, "periodic full sync needed (>7 days since last)"
+        return False, "incremental sync (valid watermark)"
+
+    async def generate_entities(
+        self,
+        *,
+        cursor: SyncCursor | None = None,
+        files: FileService | None = None,
+        node_selections: list[NodeSelectionData] | None = None,
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Generate all iManage entities using full or incremental sync.
+
+        Tracked groups are deliberately not seeded from the cursor: every run re-reads
+        the security of every workspace it syncs, so the set rebuilds from the source.
+        Restoring the previous set would keep expanding a group whose access the firm
+        has just revoked.
+        """
+        await self._resolve_customer_id()
+        selected = self._selected_workspaces(node_selections)
+        is_full, reason = self._should_do_full_sync(cursor)
+        scope_label = f"TARGETED ({len(selected)} workspaces) " if selected else ""
+        self.logger.info(
+            f"Sync strategy: {scope_label}{'FULL' if is_full else 'INCREMENTAL'} ({reason})"
+        )
+
+        if is_full:
+            async for entity in self._full_sync(cursor, files, selected):
+                yield entity
+        else:
+            async for entity in self._incremental_sync(cursor, files, selected):
+                yield entity
+
+        if cursor:
+            cursor.update(tracked_groups=dict(self._tracked_groups))
+
+    async def _workspace_records(
+        self, selected: List[Tuple[str, str]]
+    ) -> AsyncGenerator[Tuple[str, Dict], None]:
+        """(library, workspace profile) pairs for the whole estate or the selection."""
+        if selected:
+            for library_id, workspace_id in selected:
+                library = library_id or workspace_id.partition("!")[0]
+                url = self._customer_path(f"/libraries/{library}/workspaces/{workspace_id}")
+                try:
+                    data = await self._get(url)
+                except SourceAuthError:
+                    raise
+                except Exception as e:
+                    # Never widen: a selected workspace that vanished or was walled
+                    # away costs that one root, not the run.
+                    self.logger.warning(
+                        f"Selected workspace {workspace_id} could not be read ({e}); "
+                        "skipping it — the remaining selected workspaces still sync"
+                    )
+                    continue
+                payload = self._payload(data)
+                if isinstance(payload, dict) and payload.get("id"):
+                    yield library, payload
+            return
+
+        for library_id in await self._libraries():
+            async for record in self._workspaces(library_id):
+                yield library_id, record
+
+    async def _sync_workspace(
+        self,
+        library_id: str,
+        record: Dict,
+        files: FileService | None,
+    ) -> AsyncGenerator[Tuple[BaseEntity, List[str], List[str]], None]:
+        """Yield a workspace's entities along with its viewers and document ids."""
+        workspace = IManageWorkspaceEntity.from_api(record, library_id=library_id)
+        if workspace is None:
+            return
+        access = await self._security(
+            library_id=library_id,
+            object_type="workspaces",
+            object_id=workspace.workspace_id,
+        )
+        workspace.access = access
+        viewers = _access_key(access)
+        document_ids: List[str] = []
+        yield workspace, viewers, document_ids
+
+        breadcrumbs = [
+            Breadcrumb(
+                entity_id=workspace.workspace_id,
+                name=workspace.name,
+                entity_type="IManageWorkspaceEntity",
+            )
+        ]
+        async for entity in self._walk_folder(
+            workspace.workspace_id,
+            library_id=library_id,
+            workspace_id=workspace.workspace_id,
+            container_access=access,
+            breadcrumbs=breadcrumbs,
+            files=files,
+            seen=set(),
+            document_ids=document_ids,
+        ):
+            yield entity, viewers, document_ids
+
+    async def _full_sync(
+        self,
+        cursor: SyncCursor | None,
+        files: FileService | None,
+        selected: List[Tuple[str, str]],
+    ) -> AsyncGenerator[BaseEntity, None]:
+        watermark = datetime.now(UTC).isoformat()
+        workspace_acls: Dict[str, List[str]] = {}
+        workspace_documents: Dict[str, List[str]] = {}
+        entity_count = 0
+
+        async for library_id, record in self._workspace_records(selected):
+            workspace_id = str(record.get("id") or "").strip()
+            if not workspace_id:
+                continue
+            async for entity, viewers, document_ids in self._sync_workspace(
+                library_id, record, files
+            ):
+                workspace_acls[workspace_id] = viewers
+                workspace_documents[workspace_id] = document_ids
+                yield entity
+                entity_count += 1
+
+        if cursor:
+            schema = IManageCursor(**cursor.data)
+            schema.edited_since = watermark
+            schema.full_sync_required = False
+            schema.last_full_sync_timestamp = datetime.now(UTC).isoformat()
+            schema.last_entity_changes_count = entity_count
+            schema.workspace_acls = workspace_acls
+            schema.workspace_documents = workspace_documents
+            cursor.update(**schema.model_dump())
+
+        self.logger.info(f"Full sync complete: {entity_count} entities")
+
+    async def _incremental_sync(  # noqa: C901
+        self,
+        cursor: SyncCursor | None,
+        files: FileService | None,
+        selected: List[Tuple[str, str]],
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Drain edited documents — after diffing workspace security."""
+        cursor_data = cursor.data if cursor else {}
+        schema = IManageCursor(**cursor_data)
+        if not schema.edited_since:
+            async for entity in self._full_sync(cursor, files, selected):
+                yield entity
+            return
+
+        watermark = datetime.now(UTC).isoformat()
+        previous_acls = {str(k): list(v or []) for k, v in (schema.workspace_acls or {}).items()}
+        workspace_documents = {
+            str(k): [str(item) for item in v]
+            for k, v in (schema.workspace_documents or {}).items()
+        }
+        current_acls: Dict[str, List[str]] = {}
+        changes = 0
+        emitted: set[str] = set()
+
+        try:
+            records = [pair async for pair in self._workspace_records(selected)]
+        except SourceAuthError:
+            raise
+        except Exception as e:
+            self.logger.warning(f"Workspace listing failed: {e}")
+            if cursor:
+                cursor.update(full_sync_required=True)
+            return
+
+        if not records and previous_acls:
+            # An empty listing where the last run saw workspaces is far more likely to
+            # be a withdrawn grant or an outage than a firm deleting its estate — and
+            # ``_get`` reports 403 and 404 as an empty body, so both arrive here
+            # looking identical. Falling through would take the deletion path and empty
+            # the index.
+            self.logger.warning(
+                "Workspace listing came back empty but the previous run saw "
+                f"{len(previous_acls)}; treating it as unreadable rather than deleted"
+            )
+            if cursor:
+                cursor.update(full_sync_required=True)
+            return
+
+        libraries: set[str] = set()
+        for library_id, record in records:
+            workspace_id = str(record.get("id") or "").strip()
+            if not workspace_id:
+                continue
+            libraries.add(library_id)
+
+            access = await self._security(
+                library_id=library_id, object_type="workspaces", object_id=workspace_id
+            )
+            viewers = _access_key(access)
+            current_acls[workspace_id] = viewers
+
+            if previous_acls.get(workspace_id) == viewers:
+                continue
+
+            # Re-secured: re-emit the whole workspace so every document carries the new
+            # audience. Nothing in the document feed would have reported this.
+            self.logger.info(f"Workspace {workspace_id} security changed; re-emitting it")
+            async for entity, _viewers, document_ids in self._sync_workspace(
+                library_id, record, files
+            ):
+                workspace_documents[workspace_id] = document_ids
+                emitted.add(getattr(entity, "document_id", ""))
+                yield entity
+                changes += 1
+
+        for library_id in sorted(libraries):
+            async for entity in self._edited_documents(
+                library_id, schema.edited_since, current_acls, files, emitted
+            ):
+                yield entity
+                changes += 1
+
+        for workspace_id in sorted(set(previous_acls) - set(current_acls)):
+            for document_id in workspace_documents.pop(workspace_id, []):
+                yield IManageDocumentDeletionEntity(
+                    document_id=document_id, deletion_status="removed", breadcrumbs=[]
+                )
+                changes += 1
+
+        if cursor:
+            current = IManageCursor(**cursor.data)
+            current.edited_since = watermark
+            current.last_entity_changes_count = changes
+            current.workspace_acls = current_acls
+            current.workspace_documents = {
+                workspace_id: ids
+                for workspace_id, ids in workspace_documents.items()
+                if workspace_id in current_acls
+            }
+            cursor.update(**current.model_dump())
+
+        self.logger.info(f"Incremental sync complete: {changes} changes processed")
+
+    async def _edited_documents(
+        self,
+        library_id: str,
+        edited_since: str,
+        current_acls: Dict[str, List[str]],
+        files: FileService | None,
+        emitted: set[str],
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Documents in one library edited since the watermark."""
+        url = self._customer_path(f"/libraries/{library_id}/documents/search")
+        try:
+            data = await self._get(url, params={"edit_date_from": edited_since[:10]})
+        except SourceAuthError:
+            raise
+        except Exception as e:
+            self.logger.warning(f"Edited-document search failed for {library_id}: {e}")
+            return
+
+        for record in self._records(data):
+            document_id = str(record.get("id") or "").strip()
+            if not document_id or document_id in emitted:
+                continue
+            workspace_id = str(record.get("workspace_id") or "").strip()
+            # A document whose workspace this run could not read keeps unknown access
+            # rather than the last audience we happened to remember.
+            container_access = _access_from_key(current_acls.get(workspace_id))
+            breadcrumbs = (
+                [
+                    Breadcrumb(
+                        entity_id=workspace_id,
+                        name=str(record.get("workspace_name") or workspace_id),
+                        entity_type="IManageWorkspaceEntity",
+                    )
+                ]
+                if workspace_id
+                else []
+            )
+            entity = await self._document_entity(
+                record,
+                library_id=library_id,
+                folder_id=None,
+                container_access=container_access,
+                breadcrumbs=breadcrumbs,
+                files=files,
+            )
+            if entity is not None:
+                yield entity
+
+    # ------------------------------------------------------------------------ browse
+
+    async def get_browse_children(
+        self,
+        parent_node_id: Optional[str] = None,
+    ) -> List[BrowseNode]:
+        """List libraries, then their workspaces, so an operator can pick matters.
+
+        Two levels because an estate has a handful of libraries and thousands of
+        matters; offering every workspace at once is a picker nobody can use.
+        """
+        await self._resolve_customer_id()
+        if not parent_node_id:
+            return [
+                BrowseNode(
+                    source_node_id=f"library:{library_id}",
+                    node_type="folder",
+                    title=library_id,
+                    has_children=True,
+                    node_metadata={"library_id": library_id},
+                )
+                for library_id in await self._libraries()
+            ]
+
+        _kind, metadata = self.parse_browse_node_id(parent_node_id)
+        library_id = str(metadata.get("library_id") or "")
+        if not library_id:
+            return []
+        nodes: List[BrowseNode] = []
+        async for record in self._workspaces(library_id):
+            identifier = str(record.get("id") or "").strip()
+            if not identifier:
+                continue
+            name = str(record.get("name") or identifier)
+            description = record.get("description")
+            nodes.append(
+                BrowseNode(
+                    source_node_id=identifier,
+                    node_type="folder",
+                    title=f"{name} — {description}" if description else name,
+                    has_children=False,
+                    node_metadata={"workspace_id": identifier, "library_id": library_id},
+                )
+            )
+        return nodes
+
+    def parse_browse_node_id(self, node_id: str) -> tuple:
+        """Decode a browse id: ``library:NAME`` for a library, else a workspace id."""
+        if node_id.startswith("library:"):
+            return "folder", {"library_id": node_id.partition(":")[2]}
+        return "folder", {
+            "workspace_id": node_id,
+            "library_id": node_id.partition("!")[0] if "!" in node_id else "",
+        }
+
+    async def validate(self) -> None:
+        """Validate credentials by asking iManage which libraries the account can see."""
+        customer_id = await self._resolve_customer_id()
+        await self._get(f"{self._api}/customers/{customer_id}/libraries")

--- a/tests/test_connector_replay.py
+++ b/tests/test_connector_replay.py
@@ -58,6 +58,14 @@ VALIDATE_ROUTES: dict[str, dict[str, Recorded]] = {
         )
     },
     "box": {"GET https://api.box.com/2.0/users/me": Recorded({"id": "1"})},
+    "imanage": {
+        "GET https://cloudimanage.com/work/api/v2/customers": Recorded(
+            {"data": [{"id": "kanzlei"}]}
+        ),
+        "GET https://cloudimanage.com/work/api/v2/customers/kanzlei/libraries": Recorded(
+            {"data": [{"id": "ACTIVE_DE"}]}
+        ),
+    },
     "notion": {"GET https://api.notion.com/v1/users/me": Recorded({"id": "user-1"})},
     "slack": {"GET https://slack.com/api/auth.test": Recorded({"ok": True, "team": "Kanzlei"})},
     "confluence": {
@@ -1873,8 +1881,17 @@ def test_only_connectors_with_a_folder_tree_declare_scoping():
     scoping = {spec.short_name for spec in CATALOG if spec.supports_scoping}
     # A mailbox, a calendar or a chat workspace has no folder tree worth scoping, and
     # claiming otherwise would offer the operator a picker that cannot be populated.
-    # Clio's tree is its matter list — flat, but a real unit of selection.
-    assert scoping == {"sharepoint_online", "onedrive", "dropbox", "box", "google_drive", "clio"}
+    # Clio's tree is its matter list and iManage's is library then workspace — both
+    # shallow, both a real unit of selection.
+    assert scoping == {
+        "sharepoint_online",
+        "onedrive",
+        "dropbox",
+        "box",
+        "google_drive",
+        "clio",
+        "imanage",
+    }
 
 
 # ----------------------------------------------------------------- SharePoint scope
@@ -2049,3 +2066,546 @@ def test_sharepoint_browse_lists_the_folder_tree_for_the_picker(tmp_path):
 
     nested = _browse("sharepoint_online", routes, tmp_path, node="folder:drive-1|f-mandate")
     assert [node["title"] for node in nested if node["node_type"] == "folder"] == ["Mandat-Neu"]
+
+
+# ---------------------------------------------------------------------- iManage Work
+#
+# Same manual matrix as NetDocuments: two containers with different security, a sync
+# that keeps them different, a security change at the source landing on the next run,
+# and documents arriving and leaving.
+#
+# iManage differs from NetDocuments in one way that matters: it states on every object
+# whether that object inherits its container's security. Inheritance here is the
+# source's own answer, so it is honoured — and an object that overrides is read on its
+# own rather than assumed.
+
+IM = "https://cloudimanage.com/work/api/v2/customers/kanzlei"
+
+
+def _im_security(default: str, *acl: dict) -> dict:
+    return {"data": {"default_security": default, "acl": list(acl)}}
+
+
+def _im_trustee(identifier: str, kind: str, level: str, **extra) -> dict:
+    return {"id": identifier, "name": identifier, "type": kind, "access_level": level, **extra}
+
+
+def _im_document(identifier: str, name: str, *, security: str = "inherit", **extra) -> dict:
+    return {
+        "id": identifier,
+        "name": name,
+        "extension": "docx",
+        "size": 12,
+        "version": 1,
+        "database": "ACTIVE_DE",
+        "document_number": identifier.partition("!")[2].partition(".")[0],
+        "default_security": security,
+        "workspace_id": "ACTIVE_DE!WS01",
+        "workspace_name": "2026-0011 Mandant GmbH",
+        "author_description": "Anwalt",
+        "class_description": "Schriftsatz",
+        "create_date": "2026-01-01T00:00:00Z",
+        "edit_date": "2026-02-01T00:00:00Z",
+        **extra,
+    }
+
+
+_IM_WALLED = {
+    "id": "ACTIVE_DE!WS01",
+    "name": "2026-0011 Mandant GmbH",
+    "database": "ACTIVE_DE",
+    "description": "Walled matter",
+    "owner_description": "Partner",
+    "custom1_description": "Mandant GmbH",
+    "custom2_description": "2026-0011",
+}
+_IM_OPEN = {
+    "id": "ACTIVE_DE!WS02",
+    "name": "2026-0012 Kunde AG",
+    "database": "ACTIVE_DE",
+    "description": "Open matter",
+    "owner_description": "Partner",
+}
+
+
+def _im_routes(**overrides) -> dict[str, Recorded]:
+    routes: dict[str, Recorded] = {
+        "GET https://cloudimanage.com/work/api/v2/customers": Recorded(
+            {"data": [{"id": "kanzlei"}]}
+        ),
+        f"GET {IM}/libraries": Recorded({"data": [{"id": "ACTIVE_DE"}]}),
+        f"GET {IM}/libraries/ACTIVE_DE/workspaces": Recorded({"data": [_IM_WALLED, _IM_OPEN]}),
+        f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01/security": Recorded(
+            _im_security("private", _im_trustee("LITIGATION", "group", "read"))
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS02/security": Recorded(
+            _im_security("public")
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS01/subfolders": Recorded({"data": []}),
+        f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS02/subfolders": Recorded({"data": []}),
+        f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS01/documents": Recorded(
+            {"data": [_im_document("ACTIVE_DE!4711.1", "Klageschrift.docx")]}
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS02/documents": Recorded(
+            {"data": [_im_document("ACTIVE_DE!4712.1", "Vertrag.docx")]}
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4711.1/download": Recorded(
+            content=b"im bytes"
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4712.1/download": Recorded(
+            content=b"im bytes"
+        ),
+        f"GET {IM}/libraries/ACTIVE_DE/groups/LITIGATION/members": Recorded(
+            {"data": [{"email": "Litigator@Kanzlei.de"}]}
+        ),
+    }
+    routes.update(overrides)
+    return routes
+
+
+def test_imanage_two_workspaces_keep_the_different_security_they_have_at_the_source(tmp_path):
+    connector, _client = build("imanage", _im_routes(), staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    by_name = {item.name: item for item in observations}
+    # Workspaces and folders are walked for context, not indexed — a matter stub would
+    # match every query weakly. The security they carry reaches their documents.
+    assert set(by_name) == {"Klageschrift.docx", "Vertrag.docx"}
+
+    walled = by_name["Klageschrift.docx"]
+    open_matter = by_name["Vertrag.docx"]
+    assert [grant["principal"] for grant in walled.acl] == ["group:imanage:litigation"]
+    # public means library-wide, which on a single-firm appliance is everyone here.
+    assert [grant["principal"] for grant in open_matter.acl] == ["role:authenticated"]
+    assert walled.acl != open_matter.acl
+
+
+def test_imanage_an_inheriting_document_takes_its_workspace_audience(tmp_path):
+    """Inheritance is iManage's own answer, not this connector guessing."""
+    connector, client = build("imanage", _im_routes(), staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    claim = next(item for item in observations if item.name == "Klageschrift.docx")
+    assert [grant["principal"] for grant in claim.acl] == ["group:imanage:litigation"]
+    # Inheriting costs no extra call: the document's security is not fetched.
+    assert not client.called("/documents/ACTIVE_DE!4711.1/security")
+
+
+def test_imanage_an_overriding_document_is_read_on_its_own(tmp_path):
+    """A restricted memo inside an open matter keeps its own, narrower audience."""
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS02/documents": Recorded(
+                {"data": [_im_document("ACTIVE_DE!4712.1", "Vertrag.docx", security="private")]}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4712.1/security": Recorded(
+                _im_security("private", _im_trustee("PARTNERS", "group", "read_write"))
+            ),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    contract = next(item for item in observations if item.name == "Vertrag.docx")
+    # Not the workspace's firm-wide audience.
+    assert [grant["principal"] for grant in contract.acl] == ["group:imanage:partners"]
+
+
+def test_imanage_no_access_is_a_wall_not_a_grant(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01/security": Recorded(
+                _im_security(
+                    "private",
+                    _im_trustee("LITIGATION", "group", "read"),
+                    _im_trustee("INTERNS", "group", "no_access"),
+                    _im_trustee("JSCHMIDT", "user", "no_access"),
+                )
+            )
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    walled = next(item for item in observations if item.name == "Klageschrift.docx")
+    principals = [grant["principal"] for grant in walled.acl]
+    assert principals == ["group:imanage:litigation"]
+    assert not any("intern" in principal for principal in principals)
+    assert not any("jschmidt" in principal for principal in principals)
+
+
+def test_imanage_a_user_trustee_with_an_address_becomes_that_address(tmp_path):
+    """An iManage login id matches no caller here; an address does."""
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01/security": Recorded(
+                _im_security(
+                    "private",
+                    _im_trustee("JSCHMIDT", "user", "read", email="Jan.Schmidt@Kanzlei.de"),
+                    _im_trustee("MMUELLER", "user", "read"),
+                )
+            )
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    walled = next(item for item in observations if item.name == "Klageschrift.docx")
+    principals = [grant["principal"] for grant in walled.acl]
+    assert "user:jan.schmidt@kanzlei.de" in principals
+    # No address: the id lands in the namespace the identity layer reconciles, rather
+    # than being dropped or guessed at.
+    assert "user:id:mmueller" in principals
+
+
+def test_imanage_a_restricted_subfolder_is_not_flattened_to_its_workspace(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS02/subfolders": Recorded(
+                {
+                    "data": [
+                        {
+                            "id": "ACTIVE_DE!F900",
+                            "name": "Vertraulich",
+                            "database": "ACTIVE_DE",
+                            "workspace_id": "ACTIVE_DE!WS02",
+                        }
+                    ]
+                }
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F900/security": Recorded(
+                _im_security("private", _im_trustee("PARTNERS", "group", "read"))
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F900/subfolders": Recorded(
+                {"data": []}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F900/documents": Recorded(
+                {"data": [_im_document("ACTIVE_DE!4713.1", "Geheim.docx")]}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4713.1/download": Recorded(
+                content=b"im bytes"
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/groups/PARTNERS/members": Recorded(
+                {"data": [{"email": "partner@kanzlei.de"}]}
+            ),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    secret = next(item for item in observations if item.name == "Geheim.docx")
+    # The workspace is firm-wide; the folder is not, and the document inherits the
+    # folder rather than jumping back up to the workspace.
+    assert [grant["principal"] for grant in secret.acl] == ["group:imanage:partners"]
+    assert "Vertraulich" in secret.path
+
+
+def test_imanage_expands_groups_into_memberships(tmp_path):
+    connector, _client = build("imanage", _im_routes(), staging=tmp_path)
+    try:
+        list(connector.full_scan())
+        memberships = connector.memberships()
+    finally:
+        connector.close()
+
+    rows = {(row["group_id"], row["member_id"]) for row in memberships}
+    assert ("imanage:litigation", "litigator@kanzlei.de") in rows
+    assert all(row["member_id"] == row["member_id"].casefold() for row in memberships)
+
+
+def test_imanage_unreadable_security_leaves_the_workspace_unknown(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01/security": Recorded(
+                {}, status=403
+            )
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    # The documents that inherit the unreadable workspace stay unknown rather than
+    # becoming public or empty.
+    claim = next(item for item in observations if item.name == "Klageschrift.docx")
+    assert claim.acl is None
+
+
+def test_imanage_an_unreadable_document_override_never_falls_back_to_the_container(tmp_path):
+    """The whole point of an override is usually that it is narrower."""
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS02/documents": Recorded(
+                {"data": [_im_document("ACTIVE_DE!4712.1", "Vertrag.docx", security="private")]}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4712.1/security": Recorded(
+                {}, status=403
+            ),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    contract = next(item for item in observations if item.name == "Vertrag.docx")
+    assert contract.acl is None
+
+
+def test_imanage_permission_mirroring_can_be_turned_off(tmp_path):
+    connector, client = build(
+        "imanage", _im_routes(), staging=tmp_path, config={"mirror_permissions": False}
+    )
+    try:
+        observations = list(connector.full_scan())
+    finally:
+        connector.close()
+
+    assert observations, "turning off the mirror must not empty the sync"
+    assert all(item.acl is None for item in observations)
+    assert not client.called("/security")
+
+
+def test_imanage_scoped_to_one_workspace_never_reads_the_other(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01": Recorded(
+                {"data": _IM_WALLED}
+            )
+        }
+    )
+    connector, client = build(
+        "imanage",
+        routes,
+        staging=tmp_path,
+        node_selections=[
+            NodeSelectionData(
+                source_node_id="ACTIVE_DE!WS01",
+                node_type="folder",
+                node_metadata={"workspace_id": "ACTIVE_DE!WS01", "library_id": "ACTIVE_DE"},
+            )
+        ],
+    )
+    try:
+        names = {item.name for item in connector.full_scan()}
+    finally:
+        connector.close()
+
+    assert "Klageschrift.docx" in names
+    assert "Vertrag.docx" not in names
+    assert not client.called("/workspaces/ACTIVE_DE!WS02")
+
+
+def test_imanage_browse_offers_libraries_then_workspaces(tmp_path):
+    connector, _client = build("imanage", _im_routes(), staging=tmp_path)
+    try:
+        libraries = connector.browse_children(None)
+        workspaces = connector.browse_children("library:ACTIVE_DE")
+    finally:
+        connector.close()
+
+    assert [node["source_node_id"] for node in libraries] == ["library:ACTIVE_DE"]
+    assert all(node["has_children"] for node in libraries)
+    assert {node["source_node_id"] for node in workspaces} == {
+        "ACTIVE_DE!WS01",
+        "ACTIVE_DE!WS02",
+    }
+
+
+def _im_cursor(**overrides) -> dict:
+    data = {
+        "edited_since": "2026-02-15T00:00:00+00:00",
+        "full_sync_required": False,
+        "last_full_sync_timestamp": datetime.now(UTC).isoformat(),
+        "workspace_acls": {
+            "ACTIVE_DE!WS01": ["group:imanage:litigation"],
+            "ACTIVE_DE!WS02": ["role:authenticated"],
+        },
+        "workspace_documents": {
+            "ACTIVE_DE!WS01": ["ACTIVE_DE!4711.1"],
+            "ACTIVE_DE!WS02": ["ACTIVE_DE!4712.1"],
+        },
+    }
+    data.update(overrides)
+    return data
+
+
+def test_imanage_incremental_picks_up_documents_edited_since_the_watermark(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/documents/search": Recorded(
+                {"data": [_im_document("ACTIVE_DE!4799.1", "Nachtrag.docx")]}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/ACTIVE_DE!4799.1/download": Recorded(
+                content=b"im bytes"
+            ),
+        }
+    )
+    connector, client = build("imanage", routes, staging=tmp_path, cursor_data=_im_cursor())
+    try:
+        batch = connector.changes(None)
+    finally:
+        connector.close()
+
+    assert {item.name for item in batch.observations} == {"Nachtrag.docx"}
+    assert client.called("edit_date_from")
+    assert json.loads(batch.next_cursor)["edited_since"] > "2026-02-15"
+
+
+def test_imanage_incremental_re_emits_a_workspace_whose_security_changed(tmp_path):
+    """Re-securing a matter moves no document timestamp; only the diff catches it."""
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces/ACTIVE_DE!WS01/security": Recorded(
+                _im_security("private", _im_trustee("PARTNERS", "group", "read"))
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/search": Recorded({"data": []}),
+            f"GET {IM}/libraries/ACTIVE_DE/groups/PARTNERS/members": Recorded(
+                {"data": [{"email": "partner@kanzlei.de"}]}
+            ),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path, cursor_data=_im_cursor())
+    try:
+        batch = connector.changes(None)
+        memberships = connector.memberships()
+    finally:
+        connector.close()
+
+    by_name = {item.name: item for item in batch.observations}
+    assert "Klageschrift.docx" in by_name
+    assert [grant["principal"] for grant in by_name["Klageschrift.docx"].acl] == [
+        "group:imanage:partners"
+    ]
+    # The revoked group is not expanded any more.
+    assert not any("litigation" in row["group_id"] for row in memberships)
+    assert json.loads(batch.next_cursor)["workspace_acls"]["ACTIVE_DE!WS01"] == [
+        "group:imanage:partners"
+    ]
+
+
+def test_imanage_incremental_deletes_documents_of_a_workspace_that_closed(tmp_path):
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/workspaces": Recorded({"data": [_IM_OPEN]}),
+            f"GET {IM}/libraries/ACTIVE_DE/documents/search": Recorded({"data": []}),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path, cursor_data=_im_cursor())
+    try:
+        batch = connector.changes(None)
+    finally:
+        connector.close()
+
+    assert set(batch.deleted_external_ids) == {"ACTIVE_DE!4711.1"}
+
+
+@pytest.mark.parametrize(
+    ("label", "response"),
+    [
+        ("forbidden", Recorded({}, status=403)),
+        ("empty", Recorded({"data": []})),
+    ],
+)
+def test_imanage_an_unreadable_workspace_listing_never_deletes_the_estate(
+    label, response, tmp_path
+):
+    routes = _im_routes(**{f"GET {IM}/libraries/ACTIVE_DE/workspaces": response})
+    connector, _client = build("imanage", routes, staging=tmp_path, cursor_data=_im_cursor())
+    try:
+        batch = connector.changes(None)
+    finally:
+        connector.close()
+
+    assert batch.deleted_external_ids == [], label
+    assert batch.observations == [], label
+    assert json.loads(batch.next_cursor)["full_sync_required"] is True, label
+
+
+def test_imanage_a_public_workspace_does_not_re_sync_itself_on_every_run(tmp_path):
+    """is_public has to be part of the ACL snapshot, or the diff never matches.
+
+    A public workspace mirrors to an empty viewer list plus the public flag. Snapshotting
+    only the viewers made it differ from its own recomputed value every time, so every
+    open matter re-synced its whole contents on every incremental run.
+    """
+    routes = _im_routes(**{f"GET {IM}/libraries/ACTIVE_DE/documents/search": Recorded({"data": []})})
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        list(connector.full_scan())
+        first = json.loads(connector.cursor_state())
+    finally:
+        connector.close()
+
+    connector, _client = build(
+        "imanage",
+        routes,
+        staging=tmp_path,
+        cursor_data={**first, "full_sync_required": False},
+    )
+    try:
+        batch = connector.changes(None)
+    finally:
+        connector.close()
+
+    # Nothing was edited and nothing was re-secured, so nothing comes back.
+    assert batch.observations == []
+    assert first["workspace_acls"]["ACTIVE_DE!WS02"] == ["role:authenticated"]
+
+
+def test_imanage_containers_are_walked_for_context_but_never_indexed(tmp_path):
+    """A workspace or folder stub in the corpus matches every query weakly."""
+    routes = _im_routes(
+        **{
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!WS01/subfolders": Recorded(
+                {
+                    "data": [
+                        {
+                            "id": "ACTIVE_DE!F100",
+                            "name": "Schriftsaetze",
+                            "database": "ACTIVE_DE",
+                        }
+                    ]
+                }
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F100/security": Recorded(
+                _im_security("inherit")
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F100/subfolders": Recorded(
+                {"data": []}
+            ),
+            f"GET {IM}/libraries/ACTIVE_DE/folders/ACTIVE_DE!F100/documents": Recorded(
+                {"data": []}
+            ),
+        }
+    )
+    connector, _client = build("imanage", routes, staging=tmp_path)
+    try:
+        names = {item.name for item in connector.full_scan()}
+    finally:
+        connector.close()
+
+    assert names == {"Klageschrift.docx", "Vertrag.docx"}
+    assert "Schriftsaetze" not in names
+    assert "2026-0011 Mandant GmbH" not in names

--- a/tests/test_connector_scoping.py
+++ b/tests/test_connector_scoping.py
@@ -80,7 +80,17 @@ def test_only_folder_shaped_sources_advertise_scoping():
     Advertising it would put a folder picker in front of an operator that cannot work.
     """
     scoped = {spec.short_name for spec in CATALOG if spec.supports_scoping}
-    assert scoped == {"sharepoint_online", "onedrive", "google_drive", "dropbox", "box", "clio"}
+    assert scoped == {
+        "sharepoint_online",
+        "onedrive",
+        "google_drive",
+        "dropbox",
+        "box",
+        "clio",
+        # iManage picks by library, then by workspace: an estate has thousands of
+        # matters, and the matter is the unit a firm draws its walls around.
+        "imanage",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -708,8 +708,10 @@ def test_planned_connectors_are_roadmap_cards_and_nothing_more():
     assert {entry["id"] for entry in planned_entries} == {
         item.short_name for item in PLANNED
     }
-    # The names a law firm actually looks for.
-    assert {"imanage", "netdocuments", "ra_micro", "datev_anwalt", "annotext"} <= {
+    # The names a law firm actually looks for. iManage has left this list by being
+    # built — a roadmap card graduating into a ConnectorSpec is the point of the
+    # list, not a break in it.
+    assert {"netdocuments", "ra_micro", "datev_anwalt", "annotext"} <= {
         entry["id"] for entry in planned_entries
     }
     assert not {item.short_name for item in PLANNED} & {spec.short_name for spec in BUILT}
@@ -718,7 +720,7 @@ def test_planned_connectors_are_roadmap_cards_and_nothing_more():
         assert entry["acl_sync"] is None and entry["incremental"] is None, entry["id"]
         assert entry["notes"], entry["id"]
     with pytest.raises(Exception):
-        get("imanage")
+        get("ra_micro")
 
 
 # ------------------------------------------------------- mirrored source permissions


### PR DESCRIPTION
iManage Work is the DMS most large firms run and the name our catalog leads with. This builds it.

**Not launch-ready.** It stays out of `UI_AVAILABLE` until one live tenant sync confirms the inferred paths.

Companion to #4 (NetDocuments). Independent — review either first. Both touch `acl.py`, `configs.py`, `registry.py`, `providers.yaml` and the three test files, in disjoint places.

## Where this came from

Same source as #4: `microsoft/PowerPlatformConnectors` → `certified-connectors/iManage Work/apiDefinition.swagger.json`, MIT.

iManage's definition is much richer than NetDocuments'. It declares 17 schemas including the security payload in full, so the permission model here is built on a verified schema rather than an inferred one.

The catch: that definition describes Microsoft's *facade* (`cloudimanage.com/automate/work`), not the native REST API. The paths here are the native `/work/api/v2/...` ones, and are partly inferred.

## How to connect

| | |
| --- | --- |
| Registration | Control Center → Applications → Add manually. Requires **NRTADMIN** membership or a Tier 2 Control Center role |
| Credentials | API Key + API Secret, entered per connection. *Auto-Generate* shows the secret once |
| Customer id | Every path is scoped by it. Read from the authorizing account at connect time; settable explicitly as a fallback |
| Auth header | `X-Auth-Token`, not `Authorization: Bearer` |
| Scope requested | `read` only |
| Host | `cloudimanage.com` default; self-hosted firms change one field rather than needing their own provider entry |

**There is no self-service route to a tenant.** Registering needs an existing iManage environment: the firm's own, a firm's sandbox tenant, or the Technology Partner programme (a sales-qualified contact form, not a signup).

## How sync works

Library → workspace (the matter) → folder → document.

- **Pagination** — offset/limit, 100 per page.
- **Scoping** — two levels, library then workspace. An estate has a handful of libraries and thousands of matters; a flat list is a picker nobody can use.
- **Containers walked, not indexed** — pinned by a test rather than left to the classifier's heuristics.
- **Incremental** — per-library `edit_date` search plus a workspace-security diff, because container-level changes move no document timestamp.
- **Deletions** — no tombstone; reconciled from the previous run's per-workspace ids.

## How permission sync works

iManage states security as a `default_security` value plus an ACL of trustees with access levels, and — unlike NetDocuments — states on each object whether it inherits from its container. That makes the model materially better defined here.

Behaviour details, including how each case is handled and why, are in the connector's module docstring, its config field descriptions, and `docs/src/content/docs/connectors/imanage.md`. Please review them there rather than in this description.

## Two bugs the tests caught

1. **A snapshot comparison was incomplete**, so a whole class of workspace re-synced its entire contents on every incremental run. Now compared through `_access_key`, which also keeps *unknown* distinct from *empty*.
2. **An unreadable listing could be mistaken for an empty one** — same class of bug as #4; both now ask for a full sync instead.

## One thing #4 needed, found here

`is_container()` classifies by class name against token lists. iManage's classes land correctly. NetDocuments' do not, because the vendor's own name collides with a content token — its containers were being indexed as stubs. That is fixed on #4. This branch changes nothing in the classifier; it pins the correct behaviour with a test so a future change cannot regress it silently.

## Verified vs inferred

| Area | Status |
| --- | --- |
| Operations, security payload schema, access levels, `default_security` values | **Verified** — declared in full |
| Document / folder / workspace profile fields | **Verified** — declared schemas |
| `folders` / `subfolders` path shape | **Verified** — matches published third-party integration docs |
| `/security`, `/documents/search`, `/groups/{id}/members` paths | **Inferred** — facade ≠ native REST |
| `X-Auth-Token` header, OAuth endpoints | **Inferred** |
| `customers` listing for customer-id discovery | **Inferred** |
| Offset/limit pagination | **Inferred** |
| Live tenant sync | **Not run** |

## Tests

20 replay tests: two matters with different security staying different through a sync, the inherit/override cases, container-level changes landing on the next run, group expansion, scoping, browse, documents arriving and leaving, and the failure modes above. Each asserts one behaviour and is named for it.

`295 passed` across the connector, pipeline and sync suites. `ruff` clean. Full-suite failures are the same 30 pre-existing environment failures noted on #4.

## Review notes

Read the module docstring first. `docs/src/content/docs/connectors/imanage.md` is the operator-facing version.

The main inferred surface is the native path set — `/security` and `/documents/search` are the two to sanity-check against a real tenant first.

Anything needing discussion of specific access-control behaviour: internal channels, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
