### PR TITLE
Support Dropbox Business team tokens, acting over the team space

### DIFF
--- a/docs/src/content/docs/connectors/dropbox.md
+++ b/docs/src/content/docs/connectors/dropbox.md
@@ -16,6 +16,7 @@ members are read once and applied to everything inside it.
 | Permission mirror | Yes, per shared folder, plus per-file shares |
 | Group expansion | Dropbox Business team groups |
 | Token type | Refresh token |
+| Team support | Dropbox Business team tokens, indexing the shared team space |
 
 ## Register the app in the Dropbox App Console
 
@@ -25,26 +26,62 @@ Create the app from the account that owns the estate, at
 1. **Create app** → **Scoped access** → access type **Full Dropbox**. An
    App-folder app can only ever see one directory it created for itself.
 2. **Permissions** tab: tick `account_info.read`, `files.metadata.read`,
-   `files.content.read` and `sharing.read`. For group expansion also tick
-   `groups.read`, which is a team scope and needs a Dropbox Business team.
-   Press **Submit** at the bottom — that is a separate step from ticking the
-   boxes.
+   `files.content.read` and `sharing.read`. On a Dropbox Business team — the
+   normal case for a firm — also tick the team scopes: `team_info.read`,
+   `team_data.member`, `team_data.content.read`, `files.team_metadata.read`,
+   `members.read` and `groups.read`. Press **Submit** at the bottom — that is
+   a separate step from ticking the boxes.
 
    `account_info.read` is not optional: every sync opens with
    `users/get_current_account`, both to validate the credential and to learn
    the owner's address, which is what makes an unshared file readable by the
    account that authorized the connection. Without it the first call fails and
    the connection looks dead rather than under-scoped.
+
+   The OpenID scopes (`openid`, `profile`, `email`) cannot coexist with team
+   scopes — the console says so itself. Leave them off; this connector does
+   not use them.
 3. **Settings** → **OAuth 2** → **Redirect URIs**: add the URI shown in the
    setup modal.
 4. **Settings** → **App key and App secret**: the App key is the client id, the
    App secret is the client secret.
 
-On a Dropbox Business team a team admin has to approve the app before it can be
-installed.
-
 Permissions ticked *after* a token was issued do not apply to that token.
 Change the Permissions tab first, then authorize.
+
+## Dropbox Business teams
+
+Dropbox has two kinds of credential, and which one an app produces is decided
+by its scopes, not by anything this appliance sends: an app with team scopes
+authorized by a team admin yields a **team token**, anything else a **user
+token**. They are not interchangeable. A user token is refused by every
+`/2/team/*` route regardless of what was ticked, and a team token cannot touch
+a file until it names the team member it acts as. The connector probes
+`team/get_info` once per run and handles both:
+
+- **Team token.** The connection acts as the admin who authorized it (or the
+  member named in **Act As Member**), resolved through
+  `team/token/get_authenticated_admin` — and reads the team's shared space,
+  the team folders a firm actually works out of, by pointing every file
+  request at the team's root namespace. Group expansion uses the team
+  directory natively.
+- **User token.** Exactly the behaviour described elsewhere on this page: the
+  authorizing account's own estate, group expansion only as far as the token
+  can reach.
+
+Two things follow for a team app:
+
+- The **Generate access token** button disappears from the App Console once
+  team scopes are ticked. A team token can only come from the OAuth flow,
+  authorized by a **team admin**; authorize from the setup modal as usual.
+- After the admin authorizes, the app's **Development teams** counter on the
+  Settings tab should read 1/5. At 0/5 the team never linked, and every
+  `/2/team/*` call will be refused no matter the scopes.
+
+Re-authorizing a connection with the other kind of token, changing the acting
+member, or toggling the team space all cause the next sync to crawl rather
+than resume: the stored change cursors describe an estate the new identity is
+not looking at.
 
 ## Connect
 
@@ -59,6 +96,8 @@ selection syncs the whole account.
 | Exclude Path | empty | Path fragment to skip, for example `/archiv`. Matched case-insensitively against the lowercase path. |
 | Mirror Sharing Members | on | Read sharing members and mirror them as grants. Off leaves permissions unknown, and documents stay invisible until an administrator grants access at project level. |
 | Expand Dropbox Groups | on | Resolve Dropbox group members through the team API, so a folder shared with a group is reachable by the people in it. |
+| Index The Team Space | on | With a team token, index the team's shared space — the team folders — rather than the home directory of the member the token acts as. Ignored by a user token. |
+| Act As Member | empty | The team member whose access a team token uses, by email address. Blank acts as the admin who authorized the token, with admin reach over the team space; a named member reaches what that member can reach. Ignored by a user token. |
 
 ## How permissions are resolved
 

--- a/src/knowledge_index/connectors/configs.py
+++ b/src/knowledge_index/connectors/configs.py
@@ -125,6 +125,31 @@ class DropboxConfig(SourceConfig):
         ),
     )
 
+    index_team_space: bool = Field(
+        default=True,
+        title="Index The Team Space",
+        description=(
+            "With a Dropbox Business team token, index the team's shared space — the team "
+            "folders everyone works out of — rather than the home directory of the single "
+            "member the token acts as. The team space is what a firm means by its file "
+            "server. Turn it off to index only that member's own Dropbox. A user token "
+            "can reach nothing but its own account, so this does not apply to one."
+        ),
+    )
+
+    act_as_email: str = Field(
+        default="",
+        title="Act As Member",
+        description=(
+            "Email address of the Dropbox Business team member this connection acts as. "
+            "Leave blank to act as the team admin who authorized the token. A team token "
+            "cannot read a file without naming a member to read it as, so this decides "
+            "whose view of the estate is indexed: whose home directory when the team "
+            "space is off, and whose access to the team folders when it is on. Ignored "
+            "by a user token."
+        ),
+    )
+
 
 class GmailConfig(SourceConfig):
     """Gmail configuration schema."""

--- a/src/knowledge_index/connectors/cursors/dropbox.py
+++ b/src/knowledge_index/connectors/cursors/dropbox.py
@@ -64,6 +64,15 @@ class DropboxCursor(BaseCursor):
         ),
     )
 
+    acting_identity: str = Field(
+        default="",
+        description=(
+            "The identity the estate was read as — token kind, acting team member and "
+            "namespace. A change means the stored cursors and path map describe a "
+            "different estate, so the next run crawls instead of resuming."
+        ),
+    )
+
     full_sync_required: bool = Field(
         default=True,
         description="Whether the next run must crawl instead of draining the delta feed.",

--- a/src/knowledge_index/connectors/runtime/providers.yaml
+++ b/src/knowledge_index/connectors/runtime/providers.yaml
@@ -315,16 +315,27 @@ providers:
         nothing that writes — and press Submit at the bottom, which is a separate step
         from ticking the boxes. account_info.read is required, not optional: every sync
         opens with users/get_current_account, so a token without it fails on the first
-        call and the connection looks dead rather than under-scoped. Add the team scope
-        groups.read to have Dropbox groups expanded into their members; it needs a
-        Dropbox Business team and is simply unavailable on a personal account.
+        call and the connection looks dead rather than under-scoped. On a Dropbox
+        Business team also tick the team scopes — team_info.read, team_data.member,
+        team_data.content.read, files.team_metadata.read, members.read and groups.read —
+        so the token can act over the team space and expand Dropbox groups; they are
+        unavailable on a personal account. Leave the OpenID scopes (openid, profile,
+        email) off: the console itself says they cannot coexist with team scopes, and
+        nothing here uses them.
       secret: >-
         Settings → App key and App secret ("Show"). The App key is the client id and the
         App secret is the client secret.
-      account: Sign in as the account whose Dropbox should be indexed.
+      account: >-
+        Sign in as the account whose Dropbox should be indexed — on a Dropbox Business
+        team, as a team admin: team scopes make Dropbox issue a team-wide token, and
+        only an admin's authorization yields one that can act over the team space.
+        After authorizing, the app's Development teams counter (Settings tab) should
+        read 1/5; at 0/5 the team never linked and every team call is refused.
       note: >-
         Permissions ticked after a token was issued do not apply to that token. Change
-        the Permissions tab first, then authorize here.
+        the Permissions tab first, then authorize here. With team scopes ticked the
+        console's "Generate access token" button disappears; a team token only comes
+        from this OAuth flow.
 
   box:
     oauth_type: with_refresh

--- a/src/knowledge_index/connectors/sources/dropbox.py
+++ b/src/knowledge_index/connectors/sources/dropbox.py
@@ -89,6 +89,28 @@ GROUPS_MEMBERS_LIST_CONTINUE = f"{API}/team/groups/members/list/continue"
 CURRENT_ACCOUNT = f"{API}/users/get_current_account"
 DOWNLOAD = f"{CONTENT}/files/download"
 
+TEAM_GET_INFO = f"{API}/team/get_info"
+TEAM_AUTHENTICATED_ADMIN = f"{API}/team/token/get_authenticated_admin"
+TEAM_MEMBERS_LIST = f"{API}/team/members/list"
+TEAM_MEMBERS_LIST_CONTINUE = f"{API}/team/members/list/continue"
+
+# Every route under /2/team/ is declared ``auth = "team"`` in dropbox/dropbox-api-spec;
+# file and sharing routes carry no auth attribute and default to ``auth = "user"``. That
+# split is why this connector has two header shapes: a team token is refused by a user
+# route unless a Select header names the member to act as, and it must *not* send that
+# header to a team route. A user token calling a team route is refused outright — with
+# HTTP 400 USER_AUTH_NOT_ALLOWED, verified live, not the 401 the docs suggest — which is
+# what the token-type probe turns into a mode decision.
+TEAM_ROUTE_PREFIX = f"{API}/team/"
+
+SELECT_USER_HEADER = "Dropbox-API-Select-User"
+SELECT_ADMIN_HEADER = "Dropbox-API-Select-Admin"
+PATH_ROOT_HEADER = "Dropbox-API-Path-Root"
+
+# The AdminTier values that may be named in Dropbox-API-Select-Admin. The fourth value,
+# member_only, is an ordinary member; selecting one as admin is refused.
+TEAM_ADMIN_TIERS = {"team_admin", "user_management_admin", "support_admin"}
+
 # The account root. Dropbox names it with an empty string, not "/".
 ACCOUNT_ROOT = ""
 
@@ -164,6 +186,21 @@ class DropboxSource(BaseSource):
     # call per group for the rest of the run.
     _team_api_available: bool
     _owner_email: str
+    _index_team_space: bool
+    _act_as_email: str
+    # None until the token has been probed; then True for a Dropbox Business team token,
+    # False for a user token. The two are different credentials, not different scopes:
+    # a team token cannot touch a file route without naming a member to act as, and a
+    # user token is refused by every /2/team/ route no matter what was ticked.
+    _team_mode: Optional[bool]
+    # The Select-User or Select-Admin header attached to every user-auth route in team
+    # mode; empty for a user token, which acts as nobody but itself.
+    _select_header: Dict[str, str]
+    # The Path-Root header that points file routes at the team's shared namespace, so
+    # the team folders — the actual file server — are what gets indexed rather than one
+    # member's home directory. Empty when indexing the home namespace.
+    _path_root_header: Dict[str, str]
+    _acting_member_id: str
 
     @classmethod
     async def create(
@@ -184,9 +221,32 @@ class DropboxSource(BaseSource):
         instance._group_names = {}
         instance._team_api_available = True
         instance._owner_email = ""
+        instance._index_team_space = config.index_team_space
+        instance._act_as_email = (config.act_as_email or "").strip().casefold()
+        instance._team_mode = None
+        instance._select_header = {}
+        instance._path_root_header = {}
+        instance._acting_member_id = ""
         return instance
 
     # ------------------------------------------------------------------------ requests
+
+    def _request_headers(self, url: str, token: str) -> Dict[str, str]:
+        """The headers one request needs, split by the route's credential class.
+
+        Team routes (``/2/team/*``) authenticate as the team itself and refuse a request
+        that carries a Select header (HTTP 400, verified live). Every other route
+        operates on a single account, so in team mode it must carry the member to act as
+        — without one, Dropbox refuses with "this API function operates on a single
+        Dropbox account" — plus the namespace to act in. For a user token both extra
+        header sets are empty and this is exactly the old single-header request.
+        """
+        headers = {"Authorization": f"Bearer {token}"}
+        if url.startswith(TEAM_ROUTE_PREFIX):
+            return headers
+        headers.update(self._select_header)
+        headers.update(self._path_root_header)
+        return headers
 
     @retry(
         stop=stop_after_attempt(5),
@@ -197,7 +257,7 @@ class DropboxSource(BaseSource):
     async def _post(self, url: str, json_data: Dict | None = None) -> Dict:
         """Make an authenticated POST request to the Dropbox API."""
         token = await self.auth.get_token()
-        headers = {"Authorization": f"Bearer {token}"}
+        headers = self._request_headers(url, token)
 
         if json_data is not None:
             response = await self.http_client.post(url, headers=headers, json=json_data)
@@ -206,7 +266,7 @@ class DropboxSource(BaseSource):
 
         if response.status_code == 401 and self.auth.supports_refresh:
             new_token = await self.auth.force_refresh()
-            headers = {"Authorization": f"Bearer {new_token}"}
+            headers = self._request_headers(url, new_token)
             if json_data is not None:
                 response = await self.http_client.post(url, headers=headers, json=json_data)
             else:
@@ -230,6 +290,124 @@ class DropboxSource(BaseSource):
             data = await self._post(continue_url, {"cursor": data.get("cursor")})
             for entry in data.get("entries", []):
                 yield entry
+
+    # ------------------------------------------------------------------------ identity
+
+    async def _ensure_identity(self) -> None:
+        """Decide, once per run, which kind of token this is and who it acts as.
+
+        A team token succeeds on ``team/get_info``; a user token is refused there —
+        HTTP 400 ``USER_AUTH_NOT_ALLOWED``, or a 401 that ``raise_for_status`` has
+        already turned into ``SourceAuthError`` — so the probe has to swallow both
+        rather than let a healthy user token read as a dead connection. On success the
+        member to act as is resolved and the namespace picked; on refusal every header
+        set stays empty and the connector behaves exactly as it always has.
+        """
+        if self._team_mode is not None:
+            return
+        try:
+            await self._post(TEAM_GET_INFO, None)
+        except Exception:
+            self._team_mode = False
+            return
+        self._team_mode = True
+
+        member_id, is_admin = await self._resolve_acting_member()
+        self._acting_member_id = member_id
+        # An admin over the team space sees every team folder; a plain member sees the
+        # ones they were given. Select-Admin is only valid for an admin tier, and only
+        # buys anything when the team space is what is being indexed.
+        header = SELECT_ADMIN_HEADER if is_admin and self._index_team_space else SELECT_USER_HEADER
+        self._select_header = {header: member_id}
+
+        if not self._index_team_space:
+            return
+        account = await self._post(CURRENT_ACCOUNT, None)
+        root_info = account.get("root_info") or {}
+        root_namespace = str(root_info.get("root_namespace_id") or "")
+        home_namespace = str(root_info.get("home_namespace_id") or "")
+        # The tag is not trusted: a team member's root_info came back tagged "user" in
+        # live testing. Differing namespaces are what actually mean there is a shared
+        # team space distinct from the member's home directory.
+        if root_namespace and root_namespace != home_namespace:
+            self._path_root_header = {
+                PATH_ROOT_HEADER: json.dumps({".tag": "root", "root": root_namespace})
+            }
+
+    async def _team_members(self) -> AsyncGenerator[Dict, None]:
+        """Yield every member of the team, across pages."""
+        data = await self._post(TEAM_MEMBERS_LIST, {"limit": 100})
+        while True:
+            for member in data.get("members") or []:
+                yield member
+            if not data.get("has_more"):
+                return
+            data = await self._post(TEAM_MEMBERS_LIST_CONTINUE, {"cursor": data.get("cursor")})
+
+    async def _resolve_acting_member(self) -> tuple[str, bool]:
+        """The team member this connection reads the estate as: (member_id, is_admin).
+
+        Unconfigured, the answer is the admin who authorized the token —
+        ``team/token/get_authenticated_admin`` returns their profile directly, no member
+        listing needed. If that route is unavailable the member list is searched for an
+        active admin tier instead. A configured address is looked up in the member list
+        and must belong to an active member: acting as a suspended account would read an
+        estate nobody can reach, and silently substituting someone else would index the
+        wrong one.
+        """
+        if not self._act_as_email:
+            try:
+                profile = (await self._post(TEAM_AUTHENTICATED_ADMIN, None)).get(
+                    "admin_profile"
+                ) or {}
+                member_id = str(profile.get("team_member_id") or "")
+                if member_id:
+                    return member_id, True
+            except SourceAuthError:
+                raise
+            except Exception as e:
+                self.logger.warning(
+                    f"Could not resolve the authenticated admin ({e}); "
+                    "falling back to the member list"
+                )
+            async for member in self._team_members():
+                profile = member.get("profile") or {}
+                role = str((member.get("role") or {}).get(".tag") or "")
+                status = str((profile.get("status") or {}).get(".tag") or "")
+                member_id = str(profile.get("team_member_id") or "")
+                if member_id and status == "active" and role in TEAM_ADMIN_TIERS:
+                    return member_id, True
+            raise SourceAuthError(
+                "This is a Dropbox Business team token, but no active admin could be "
+                "resolved to act as. Configure 'Act As Member' with a team member's "
+                "address, or authorize the connection as a team admin.",
+                source_short_name=self.short_name,
+                token_provider_kind=self.auth.provider_kind,
+            )
+
+        async for member in self._team_members():
+            profile = member.get("profile") or {}
+            email = str(profile.get("email") or "").strip().casefold()
+            if email != self._act_as_email:
+                continue
+            status = str((profile.get("status") or {}).get(".tag") or "")
+            if status != "active":
+                raise SourceAuthError(
+                    f"The configured Dropbox member {self._act_as_email} is "
+                    f"'{status or 'unknown'}', not active, so nothing can be read as "
+                    "them. Point 'Act As Member' at an active member.",
+                    source_short_name=self.short_name,
+                    token_provider_kind=self.auth.provider_kind,
+                )
+            role = str((member.get("role") or {}).get(".tag") or "")
+            return str(profile.get("team_member_id") or ""), role in TEAM_ADMIN_TIERS
+        raise SourceAuthError(
+            f"No member of the Dropbox Business team has the address "
+            f"{self._act_as_email}. 'Act As Member' must name an existing member, or be "
+            "left blank to act as the admin who authorized the token.",
+            source_short_name=self.short_name,
+            token_provider_kind=self.auth.provider_kind,
+        )
 
     # ------------------------------------------------------------------------- account
 
@@ -367,6 +545,7 @@ class DropboxSource(BaseSource):
         """
         if not self._mirror_permissions or not self._expand_team_groups:
             return
+        await self._ensure_identity()
         for group_ref in sorted(self._tracked_groups):
             if not self._team_api_available:
                 return
@@ -390,14 +569,19 @@ class DropboxSource(BaseSource):
             try:
                 data = await self._post(url, args)
             except Exception as e:
-                # Includes the 401 a personal account returns for every team endpoint,
+                # Includes the refusal a personal account gets from every team endpoint,
                 # which is why this does not re-raise SourceAuthError: the account's own
                 # file credentials are fine, it simply has no team directory.
                 self.logger.warning(
                     f"Could not expand Dropbox group {group_id}: {e}; files shared with "
                     "it stay unreachable through the group until it can be read"
                 )
-                self._team_api_available = False
+                # A team token has already proven the team API answers, so one group
+                # that cannot be read (deleted mid-run, say) must not stop the groups
+                # after it from being expanded. A user token's first refusal is the
+                # only one it will ever get a different answer to, so it stops paying.
+                if not self._team_mode:
+                    self._team_api_available = False
                 return
             for member in data.get("members") or []:
                 if not dropbox_member_is_active(member):
@@ -430,8 +614,11 @@ class DropboxSource(BaseSource):
         """
         reference = _revision_reference(entity.rev) or entity.path_lower
         token = await self.auth.get_token()
+        # The content host builds its own headers, so the member/namespace selection has
+        # to be repeated here: a team token downloading without its Select header is
+        # refused just as its listings are.
         headers = {
-            "Authorization": f"Bearer {token}",
+            **self._request_headers(DOWNLOAD, token),
             # Must be ASCII: json.dumps escapes non-ASCII by default, which is what
             # keeps a file named "Beschluss Müller.pdf" from producing an invalid header.
             "Dropbox-API-Arg": json.dumps({"path": reference}),
@@ -726,6 +913,7 @@ class DropboxSource(BaseSource):
     ) -> AsyncGenerator[BaseEntity, None]:
         """Generate Dropbox entities by crawling or by draining the change feed."""
         assert files is not None, "FileService is required for Dropbox"
+        await self._ensure_identity()
 
         schema = DropboxCursor(**(cursor.data if cursor else {}))
         self._tracked_groups.update(str(group) for group in schema.tracked_groups)
@@ -737,6 +925,14 @@ class DropboxSource(BaseSource):
         # enumerate the ones they did.
         if sorted(schema.root_cursors) != sorted(roots):
             schema.mark_full_sync_required("selected roots changed")
+        # The same is true of *who* the estate is read as and *which namespace* it is
+        # read in: a token swapped from user to team, a different acting member, or the
+        # team space toggled all mean the stored cursors and path map describe an estate
+        # this run is not looking at.
+        identity = self._acting_identity()
+        if schema.acting_identity and schema.acting_identity != identity:
+            schema.mark_full_sync_required("acting identity changed")
+        schema.acting_identity = identity
 
         scope = f"TARGETED ({len(selected)} folder roots) " if selected else ""
         if schema.needs_full_sync() or schema.needs_periodic_full_sync():
@@ -756,6 +952,13 @@ class DropboxSource(BaseSource):
                 schema.tracked_groups = sorted(self._tracked_groups)
                 cursor.update(**schema.model_dump())
 
+    def _acting_identity(self) -> str:
+        """A stable name for the estate this run reads: token kind, member, namespace."""
+        if not self._team_mode:
+            return "user"
+        namespace = "root" if self._path_root_header else "home"
+        return f"team:{self._acting_member_id}:{namespace}"
+
     # -------------------------------------------------------------------------- browse
 
     async def get_browse_children(
@@ -766,6 +969,7 @@ class DropboxSource(BaseSource):
 
         ``None`` (or ``""``) lists the account root.
         """
+        await self._ensure_identity()
         path = str(parent_node_id or "").strip().rstrip("/")
         if path and not path.startswith("/"):
             path = f"/{path}"
@@ -798,5 +1002,10 @@ class DropboxSource(BaseSource):
         return "folder", {"path": node_id}
 
     async def validate(self) -> None:
-        """Verify the token by calling /users/get_current_account (POST, no body)."""
+        """Verify the token by calling /users/get_current_account (POST, no body).
+
+        The identity probe runs first because a team token fails this exact call unless
+        it names a member to act as — a valid credential would read as a dead one.
+        """
+        await self._ensure_identity()
         await self._post(CURRENT_ACCOUNT, None)

--- a/tests/connector_replay.py
+++ b/tests/connector_replay.py
@@ -81,12 +81,27 @@ class ReplayClient:
         # folder listing and a Dropbox path walk both put the interesting part there. The
         # full call is kept alongside the bare URL so assertions can reach it.
         self.calls: list[str] = []
+        # Headers are recorded in parallel with ``calls`` rather than folded into the
+        # match string. Route patterns match on substrings, and every request carries an
+        # ``Authorization: Bearer …`` header, so folding them in would let a header value
+        # satisfy a clause that was written about a URL or a body.
+        self.headers: list[dict[str, str]] = []
         self.closed = False
 
     # -- matching -----------------------------------------------------------
 
-    def _match(self, method: str, url: str, params: Any = None, json_body: Any = None) -> Recorded:
+    def _match(
+        self,
+        method: str,
+        url: str,
+        params: Any = None,
+        json_body: Any = None,
+        headers: Any = None,
+    ) -> Recorded:
         self.requests.append((method.upper(), url))
+        # Index-aligned with ``calls`` below, so an assertion that finds a call can read
+        # the headers that went with it.
+        self.headers.append(dict(headers or {}))
         call = " ".join(
             part
             for part in (
@@ -123,9 +138,14 @@ class ReplayClient:
         return entries[-1]
 
     def _response(
-        self, method: str, url: str, params: Any = None, json_body: Any = None
+        self,
+        method: str,
+        url: str,
+        params: Any = None,
+        json_body: Any = None,
+        headers: Any = None,
     ) -> httpx.Response:
-        recorded = self._match(method, url, params, json_body)
+        recorded = self._match(method, url, params, json_body, headers)
         request = httpx.Request(method.upper(), url if url.startswith("http") else f"https://x/{url}")
         if recorded.content is not None:
             return httpx.Response(
@@ -138,7 +158,9 @@ class ReplayClient:
     # -- HttpClient surface -------------------------------------------------
 
     async def request(self, method: str, url: str, **kwargs) -> httpx.Response:
-        return self._response(method, url, kwargs.get("params"), kwargs.get("json"))
+        return self._response(
+            method, url, kwargs.get("params"), kwargs.get("json"), kwargs.get("headers")
+        )
 
     async def get(self, url: str, **kwargs) -> httpx.Response:
         return await self.request("GET", url, **kwargs)
@@ -160,7 +182,9 @@ class ReplayClient:
 
     @asynccontextmanager
     async def stream(self, method: str, url: str, **kwargs):
-        response = self._response(method, url, kwargs.get("params"), kwargs.get("json"))
+        response = self._response(
+            method, url, kwargs.get("params"), kwargs.get("json"), kwargs.get("headers")
+        )
         # aiter_bytes on a non-streamed Response works because the body is already read.
         yield response
 
@@ -178,6 +202,31 @@ class ReplayClient:
 
     def call_count(self, needle: str) -> int:
         return sum(1 for call in self.calls if needle in call)
+
+    def headers_for(self, needle: str) -> list[dict[str, str]]:
+        """The headers of every call matching ``needle``, in the order they were sent."""
+        return [
+            headers for call, headers in zip(self.calls, self.headers) if needle in call
+        ]
+
+    def header_for(self, needle: str, name: str) -> str | None:
+        """One header of the first call matching ``needle``, looked up case-insensitively.
+
+        ``None`` distinguishes "the connector did not send this header" from an empty
+        value, which is the distinction the team-token tests turn on. Raises if nothing
+        matched, so a renamed endpoint fails the assertion instead of silently passing it.
+        """
+        matches = self.headers_for(needle)
+        if not matches:
+            raise AssertionError(
+                f"no recorded call matching {needle!r}\ncalls:\n  "
+                + "\n  ".join(self.calls)
+            )
+        wanted = name.casefold()
+        for key, value in matches[0].items():
+            if key.casefold() == wanted:
+                return value
+        return None
 
 
 def build(

--- a/tests/test_dropbox_connector.py
+++ b/tests/test_dropbox_connector.py
@@ -556,6 +556,264 @@ def test_folder_members_paginate(tmp_path):
     assert {f"user:{PARTNER}", f"user:{REFERENDAR}"} <= _principals(observations, "Schmidt.txt")
 
 
+# ----------------------------------------------------------------------- team tokens
+#
+# Dropbox has two credential kinds, not two scope sets. Every /2/team/ route is
+# auth="team" in the published spec and every file and sharing route defaults to
+# auth="user": a user token is refused by the former outright, and a team token is
+# refused by the latter unless a Dropbox-API-Select-* header names the member to act
+# as. Every customer running Dropbox Business authorizes as a team, so the team path
+# is the normal one, and the header discipline is what these tests pin down — with the
+# harness recording headers out-of-band precisely so a Bearer token can never satisfy
+# a route clause by accident.
+
+TEAM_INFO_URL = f"{API}/team/get_info"
+AUTH_ADMIN = f"{API}/team/token/get_authenticated_admin"
+MEMBERS_LIST = f"{API}/team/members/list"
+
+SELECT_USER = "Dropbox-API-Select-User"
+SELECT_ADMIN = "Dropbox-API-Select-Admin"
+PATH_ROOT = "Dropbox-API-Path-Root"
+
+ADMIN_ID = "dbmid:kanzlei-admin"
+TEAM_ROOT_NS = "ns-team-root"
+HOME_NS = "ns-home"
+
+
+def _directory_member(
+    email: str, member_id: str | None = None, *, role: str = "member_only",
+    status: str = "active",
+) -> dict:
+    """One ``team/members/list`` entry: a profile plus the member's AdminTier."""
+    return {
+        "profile": {
+            "team_member_id": member_id or f"dbmid:{email}",
+            "email": email,
+            "status": {".tag": status},
+        },
+        "role": {".tag": role},
+    }
+
+
+def _team_routes(
+    *, root_ns: str = TEAM_ROOT_NS, home_ns: str = HOME_NS, members: list | None = None,
+    **kwargs,
+) -> dict[str, Recorded]:
+    """The same estate, reached through a Dropbox Business team token."""
+    routes = _routes(**kwargs)
+    routes[f"POST {TEAM_INFO_URL}"] = Recorded({"name": "Kanzlei", "num_licensed_users": 3})
+    routes[f"POST {AUTH_ADMIN}"] = Recorded(
+        {"admin_profile": {"team_member_id": ADMIN_ID, "email": OWNER,
+                           "status": {".tag": "active"}}}
+    )
+    routes[f"POST {MEMBERS_LIST}"] = Recorded(
+        {"members": members or [_directory_member(OWNER, ADMIN_ID, role="team_admin")],
+         "has_more": False}
+    )
+    routes[f"POST {ACCOUNT}"] = Recorded(
+        {
+            "account_id": "dbid:kanzlei",
+            "name": {"display_name": "Kanzlei"},
+            "email": OWNER,
+            "account_type": {".tag": "business"},
+            # Tagged "user" deliberately: that is what a real team member's account
+            # answered in live testing. The namespaces differing is what means there is
+            # a shared team space, not the tag.
+            "root_info": {".tag": "user", "root_namespace_id": root_ns,
+                          "home_namespace_id": home_ns},
+        }
+    )
+    return routes
+
+
+def _refused_probe() -> Recorded:
+    """What a user token gets from every /2/team/ route — HTTP 400, verified live,
+    not the 401 one might expect."""
+    return Recorded(
+        {"error_summary": "features/user_auth_not_allowed"}, status=400
+    )
+
+
+def test_a_team_token_acts_as_the_authenticated_admin_over_the_team_space(tmp_path):
+    """The normal customer path: a team app, authorized by an admin.
+
+    Every user-auth route — the cursor mint, the listing, the sharing reads, the
+    download on the content host — must name the member to act as and the namespace to
+    act in, or Dropbox refuses it ("this API function operates on a single Dropbox
+    account"). The Path-Root pointing at the shared team space is what makes the team
+    folders — the actual file server — the thing that gets indexed, rather than one
+    member's home directory.
+    """
+    observations, _memberships, client, _cursor = _scan(_team_routes(), tmp_path)
+
+    assert "Schmidt.txt" in {row.name for row in observations}
+    path_root = {".tag": "root", "root": TEAM_ROOT_NS}
+    for needle in (f"POST {LATEST}", f"POST {LIST} ", f"POST {FOLDER_MEMBERS}",
+                   f"POST {DOWNLOAD}"):
+        assert client.header_for(needle, SELECT_ADMIN) == ADMIN_ID, needle
+        assert json.loads(client.header_for(needle, PATH_ROOT)) == path_root, needle
+    # Probed once, not once per request.
+    assert client.call_count(f"POST {TEAM_INFO_URL}") == 1
+
+
+def test_team_routes_never_carry_a_select_header(tmp_path):
+    """The header split runs both ways: a team route with a Select header is refused
+    (HTTP 400, verified live), so attaching the headers uniformly would break exactly
+    the group expansion team mode exists to serve."""
+    _observations, memberships, client, _cursor = _scan(
+        _team_routes(group_members=[PARTNER]), tmp_path
+    )
+
+    assert [row["member_id"] for row in memberships] == [PARTNER]
+    for url in (TEAM_INFO_URL, AUTH_ADMIN, GROUP_MEMBERS):
+        for header in (SELECT_USER, SELECT_ADMIN, PATH_ROOT):
+            assert client.header_for(f"POST {url}", header) is None, (url, header)
+
+
+def test_a_user_token_keeps_the_old_single_header_requests(tmp_path):
+    """The user-token path must survive unchanged: the probe's refusal is a mode
+    decision, not an error, and no Select or Path-Root header may appear anywhere."""
+    routes = _routes()
+    routes[f"POST {TEAM_INFO_URL}"] = _refused_probe()
+
+    observations, _memberships, client, _cursor = _scan(routes, tmp_path)
+
+    assert {row.name for row in observations} == {"Schmidt.txt", "Klageschrift.txt",
+                                                  "Steuer.txt"}
+    for needle in (f"POST {LIST} ", f"POST {DOWNLOAD}", f"POST {ACCOUNT}"):
+        for header in (SELECT_USER, SELECT_ADMIN, PATH_ROOT):
+            assert client.header_for(needle, header) is None, (needle, header)
+
+
+def test_act_as_selects_that_member_rather_than_the_admin(tmp_path):
+    """An operator can pin the connection to one member's view. That member is selected
+    with Select-User — their access, not admin reach — and the admin resolution is not
+    even consulted."""
+    routes = _team_routes(members=[
+        _directory_member(OWNER, ADMIN_ID, role="team_admin"),
+        _directory_member(PARTNER, "dbmid:partnerin"),
+    ])
+
+    _observations, _memberships, client, _cursor = _scan(
+        routes, tmp_path, config={"act_as_email": PARTNER}
+    )
+
+    assert client.header_for(f"POST {LIST} ", SELECT_USER) == "dbmid:partnerin"
+    assert client.header_for(f"POST {LIST} ", SELECT_ADMIN) is None
+    # A plain member still reads the shared team space — the folders they can reach.
+    assert json.loads(client.header_for(f"POST {LIST} ", PATH_ROOT))["root"] == TEAM_ROOT_NS
+    assert not client.called(AUTH_ADMIN)
+
+
+def test_a_wrong_act_as_address_is_refused_rather_than_substituted(tmp_path):
+    """Nobody by that address on the team. Silently falling back to the admin would
+    index an estate the operator explicitly did not ask for."""
+    routes = _team_routes(members=[_directory_member(OWNER, ADMIN_ID, role="team_admin")])
+    connector, _client = build(
+        "dropbox", routes, staging=tmp_path, config={"act_as_email": OUTSIDER}
+    )
+    try:
+        with pytest.raises(SourceAuthError):
+            list(connector.full_scan())
+    finally:
+        connector.close()
+
+
+@pytest.mark.parametrize("status", ["suspended", "removed"])
+def test_acting_as_an_inactive_member_is_refused(tmp_path, status):
+    """A suspended member's estate is reachable by nobody in Dropbox; indexing as them
+    would assert grants no caller can exercise there."""
+    routes = _team_routes(members=[
+        _directory_member(OWNER, ADMIN_ID, role="team_admin"),
+        _directory_member(PARTNER, "dbmid:partnerin", status=status),
+    ])
+    connector, _client = build(
+        "dropbox", routes, staging=tmp_path, config={"act_as_email": PARTNER}
+    )
+    try:
+        with pytest.raises(SourceAuthError):
+            list(connector.full_scan())
+    finally:
+        connector.close()
+
+
+def test_admin_resolution_falls_back_to_the_member_list(tmp_path):
+    """``get_authenticated_admin`` is the direct answer, but a token that cannot call
+    it still has a directory to search: the first active admin tier serves, and a
+    member_only entry — not an admin tier — must never be selected as one."""
+    routes = _team_routes(members=[
+        _directory_member(REFERENDAR, "dbmid:referendar"),  # member_only: not eligible
+        _directory_member(OWNER, ADMIN_ID, role="user_management_admin"),
+    ])
+    routes[f"POST {AUTH_ADMIN}"] = Recorded({"error_summary": "conflict/"}, status=409)
+
+    _observations, _memberships, client, _cursor = _scan(routes, tmp_path)
+
+    assert client.header_for(f"POST {LIST} ", SELECT_ADMIN) == ADMIN_ID
+
+
+def test_the_team_space_toggle_off_reads_the_members_own_home(tmp_path):
+    """With the team space off there is nothing Select-Admin buys: the member's home is
+    read as them, in their home namespace, with no Path-Root override."""
+    _observations, _memberships, client, _cursor = _scan(
+        _team_routes(), tmp_path, config={"index_team_space": False}
+    )
+
+    assert client.header_for(f"POST {LIST} ", SELECT_USER) == ADMIN_ID
+    assert client.header_for(f"POST {LIST} ", SELECT_ADMIN) is None
+    assert client.header_for(f"POST {LIST} ", PATH_ROOT) is None
+
+
+def test_no_path_root_is_sent_when_the_team_has_no_separate_team_space(tmp_path):
+    """``root_info`` cannot be trusted by tag — a live team member answered tagged
+    "user" — so the namespaces themselves decide. Equal namespaces mean the member's
+    home is the root and a Path-Root override would be redundant at best."""
+    routes = _team_routes(root_ns="ns-same", home_ns="ns-same")
+
+    _observations, _memberships, client, _cursor = _scan(routes, tmp_path)
+
+    assert client.header_for(f"POST {LIST} ", SELECT_ADMIN) == ADMIN_ID
+    assert client.header_for(f"POST {LIST} ", PATH_ROOT) is None
+
+
+def test_one_unreadable_group_does_not_stop_the_rest_in_team_mode(tmp_path):
+    """A team token has proven the team API answers, so one group that cannot be read —
+    deleted mid-run, say — is that group's loss alone. Only a user token's refusal is
+    permanent enough to stop paying for."""
+    routes = _team_routes(
+        folder_groups=[_group_member("g:a"), _group_member("g:b")],
+    )
+    routes[f'POST {GROUP_MEMBERS} | "g:a"'] = Recorded(
+        {"error_summary": "conflict/"}, status=409
+    )
+    routes[f'POST {GROUP_MEMBERS} | "g:b"'] = Recorded(
+        {"members": [_team_member(PARTNER)], "cursor": "", "has_more": False}
+    )
+
+    _observations, memberships, client, _cursor = _scan(routes, tmp_path)
+
+    assert {row["member_id"] for row in memberships} == {PARTNER}
+    assert client.call_count(f"POST {GROUP_MEMBERS}") == 2
+
+
+def test_a_token_swap_forces_a_crawl_rather_than_resuming_the_cursor(tmp_path):
+    """A cursor minted as one identity describes that identity's estate. Re-authorizing
+    the connection with a team token (or changing the acting member) must crawl, not
+    resume a delta over paths mapped for somebody else's view."""
+    user_routes = _routes()
+    user_routes[f"POST {TEAM_INFO_URL}"] = _refused_probe()
+    cursor = _synced_cursor(user_routes, tmp_path)
+    assert cursor["acting_identity"] == "user"
+
+    # Same stored cursor, now a team token. No continue route is recorded: resuming
+    # the drain would fail loudly rather than pass by accident.
+    batch, client, state = _drain(_team_routes(), tmp_path, cursor)
+
+    assert client.call_count(f"POST {LIST} ") == 1
+    assert not client.called(CONTINUE)
+    assert _cursor_data(state)["acting_identity"] == f"team:{ADMIN_ID}:root"
+
+
 # ------------------------------------------------------------------- sync race conditions
 
 


### PR DESCRIPTION
Builds on #6. Dropbox has two credential kinds, not two scope sets: every `/2/team/` route is `auth = "team"` in `dropbox/dropbox-api-spec`, and every file and sharing route defaults to `auth = "user"`. An app with team scopes authorized by a team admin — the normal shape for a Dropbox Business team — yields a token the connector previously could not use at all: its first `users/get_current_account` was refused with *"this API function operates on a single Dropbox account"*.

## Token detection and identity

The connector probes `team/get_info` once per run.

- **Team token** — the probe succeeds. The connection acts as the admin who authorized the token, resolved directly through `team/token/get_authenticated_admin` (no member listing needed), with a search of `team/members/list` for an active admin tier — `team_admin`, `user_management_admin`, `support_admin`, never `member_only` — as the fallback. The new **Act As Member** option pins the connection to a named member instead; an address that matches nobody, or a suspended or removed member, is refused loudly rather than silently substituted with somebody else's estate.
- **User token** — the probe is refused with HTTP 400 `USER_AUTH_NOT_ALLOWED` (verified live; not the 401 one might expect), and the connector keeps exactly its old single-header behaviour.

## The header split

Every user-auth request — the cursor mint, the listings, the sharing reads, the download on the content host — carries `Dropbox-API-Select-Admin` (admin tier, team space on) or `Dropbox-API-Select-User` naming the acting member, plus `Dropbox-API-Path-Root` pointing at the team's root namespace so the shared team folders — the actual file server — are what gets indexed rather than one member's home directory. Team routes carry neither: a Select header on a team route is refused outright (HTTP 400, verified live).

The namespace decision does not trust `root_info`'s union tag, because a live team member's account answered tagged `user`; differing `root_namespace_id` and `home_namespace_id` are what mean a shared team space exists. **Index The Team Space** turns the override off and reads the acting member's home instead.

## Consequences carried through

- The cursor records the identity the estate was read as. Re-authorizing with the other kind of token, changing the acting member, or toggling the team space crawls instead of resuming a delta over paths mapped for somebody else's view.
- Group expansion no longer turns itself off after one failed read when a team token has already proven the team API answers; one unreadable group is that group's loss alone. A user token's first refusal remains permanent for the run, as before.

## Tests

The replay harness now records each request's headers in a list parallel to the call strings — deliberately not folded into the match string, where the `Authorization: Bearer` header every request carries could satisfy a route clause by accident. Tests can therefore assert the presence, the value and the *absence* of the Select and Path-Root headers per endpoint.

Twelve new tests cover both token kinds: detection, the header discipline on both route classes and the content host, admin resolution and its fallback, member pinning, inactive-member and unknown-member refusal, the team-space and namespace toggles, group-expansion resilience, and the identity-change crawl. Each load-bearing decision was mutation-checked — reverting the header split, the Path-Root, the admin-tier filter, the inactive-member refusal, the silent-substitution guard, the team-mode degradation guard or the identity comparison each turns a named test red.

Full suite: 820 passed, 2 skipped. `ruff` clean.

Verified against a live Dropbox Business team through the real connector code path: token detection, admin resolution, both Select headers, the Path-Root override, member listing, group member listing with team standing, browse, and a full sync of the team space. The recorded refusal shapes (400 on the probe, 400 on an unselected user route, 401 `invalid_select_admin` for a non-admin) are the live service's answers, not assumptions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNkm66rxxmfFVw9umNedeA)_