### PR TITLE
demo: make the workspace usable on a phone

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -79,6 +79,16 @@ text the appliance extracted at insertion — labelled as such, with the origina
 click away, because a preview that silently substitutes extracted text for a
 signed PDF is worse than no preview.
 
+**On a phone** the same three panels become tabs. They are not a second layout:
+the panels are laid over each other and all but one is hidden in CSS
+(`src/app/globals.css`, one media query, matched by `src/lib/use-compact.ts` for
+the few decisions styling cannot make). Nothing is rebuilt when the breakpoint is
+crossed, which is the point — a phone turned sideways would otherwise remount the
+chat and throw the conversation away. Selecting a document brings its tab
+forward, closing it goes back where the document was opened from, and a Word file
+is reflowed to the width of the screen rather than laid out at the width of a
+page.
+
 ## Configuration
 
 | Variable | Default | |

--- a/demo/src/app/globals.css
+++ b/demo/src/app/globals.css
@@ -5,6 +5,17 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Too small for three columns: a phone in portrait, or a phone in landscape,
+   which has the width for columns and none of the height. Kept identical to
+   COMPACT_MEDIA in src/lib/use-compact.ts, which is the same query for the few
+   decisions CSS cannot make. Written in min/max rather than range syntax so it
+   holds on the iOS versions a firm's phones actually run. */
+@custom-variant compact {
+  @media (max-width: 767.98px), (max-width: 1023.98px) and (max-height: 599.98px) {
+    @slot;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -192,6 +203,16 @@
     /* The app fills the viewport and scrolls inside its panels. A page-level
        scrollbar here would move the whole three-column layout. */
     overflow: hidden;
+    /* `height: 100%` resolves against a containing block a mobile browser sizes
+       as if its toolbars were hidden, so the composer ends up under the address
+       bar with no page scroll to reach it. `dvh` is the visible viewport, and
+       with nothing here scrolling the page it does not move around either.
+       Paired with `interactive-widget=resizes-content` in layout.tsx, which is
+       what makes the keyboard shorten the app rather than cover it. */
+    height: 100dvh;
+    /* No rubber-band on a surface that does not scroll, and no pull-to-refresh
+       above a chat somebody is scrolling back through. */
+    overscroll-behavior: none;
   }
   html {
     @apply font-sans;
@@ -256,6 +277,45 @@
   }
   &::-webkit-scrollbar-track {
     background: transparent;
+  }
+}
+
+/* =============================================================================
+   One pane at a time, on a screen that fits one.
+
+   The three panels are a split view on a desktop and a set of tabs on a phone,
+   and it is the same three panels either way: they are laid on top of each
+   other and all but one is hidden, rather than the layout being rebuilt for the
+   narrow case. That is the whole reason this is CSS and not a second React
+   tree — a phone rotating into landscape, or a window crossing the breakpoint,
+   would otherwise remount the chat and throw the conversation away.
+
+   `visibility` rather than `display`, because a hidden pane keeps its layout:
+   the tree stays scrolled where it was, the virtualizer keeps its measurements,
+   and the transcript does not jump to the top every time somebody looks at a
+   document. A visibility-hidden subtree is already out of the tab order and out
+   of the accessibility tree, so nothing behind the active tab is reachable.
+
+   The panels are the library's own elements — the group renders each child into
+   a flex item it owns — so they are addressed by the data-slot names our
+   wrappers in components/ui/resizable.tsx put on them. Unlayered, so a utility
+   class on a panel cannot put it back in the flex row.
+   ============================================================================= */
+@media (max-width: 767.98px), (max-width: 1023.98px) and (max-height: 599.98px) {
+  [data-slot="resizable-panel-group"] {
+    position: relative;
+  }
+  [data-slot="resizable-panel"] {
+    position: absolute;
+    inset: 0;
+    visibility: hidden;
+  }
+  [data-slot="resizable-panel"][data-active] {
+    visibility: visible;
+  }
+  /* Nothing to drag when there is no split. */
+  [data-slot="resizable-handle"] {
+    display: none;
   }
 }
 

--- a/demo/src/app/layout.tsx
+++ b/demo/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 
@@ -18,13 +18,30 @@ export const metadata: Metadata = {
   description: "Ask questions about the firm's indexed documents.",
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  // The app is exactly one viewport tall with nothing scrolling behind it, so
+  // the default keyboard behaviour — resize the visual viewport, leave the
+  // layout alone — hides the composer under the keyboard with no way to scroll
+  // it back. `resizes-content` shortens the app instead, which is what puts the
+  // input directly above the keys. No maximum-scale: zoom is somebody's only
+  // way to read a scanned exhibit.
+  interactiveWidget: "resizes-content",
+  // The chrome above the page is the header's black, not the paper below it.
+  themeColor: "#000000",
+};
+
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   const page = (
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="h-full">
+      {/* No height utility here: the body is `100dvh` in globals.css, and a
+          utility class would win over it and hand back the `100%` that a mobile
+          browser measures against a viewport it is not currently showing. */}
+      <body>
         <TooltipProvider delayDuration={300}>{children}</TooltipProvider>
       </body>
     </html>

--- a/demo/src/app/page.tsx
+++ b/demo/src/app/page.tsx
@@ -36,10 +36,16 @@ export default function Page() {
   return (
     <div className="flex h-full flex-col">
       {/* Black owns the chrome, exactly as it owns the hero on the product
-          page, and nothing below this bar is allowed to be black again. */}
-      <header className="flex h-16 flex-none items-center gap-5 bg-[var(--lm-black)] px-6 text-[var(--lm-ink)]">
+          page, and nothing below this bar is allowed to be black again.
+
+          On a phone the bar keeps the wordmark, the way into MCP and the
+          identity, and gives up everything that is a signpost rather than a
+          fact: the eyebrow, the divider, the three links out. Those are for
+          somebody who has finished with the demo, and on four hundred pixels
+          they would be in front of somebody who has not started. */}
+      <header className="flex h-14 flex-none items-center gap-3 bg-[var(--lm-black)] px-4 text-[var(--lm-ink)] sm:h-16 sm:gap-5 sm:px-6">
         <span
-          className="text-[20px] font-black text-[var(--lm-orange)]"
+          className="text-[17px] font-black text-[var(--lm-orange)] sm:text-[20px]"
           style={{
             // The wordmark is the product's face and it is set in the widest
             // optical width available. Geist has no expanded cut, so the system
@@ -54,9 +60,9 @@ export default function Page() {
           LegalMemory
         </span>
 
-        <span className="h-4 w-px bg-white/15" aria-hidden />
+        <span className="hidden h-4 w-px bg-white/15 sm:block" aria-hidden />
 
-        <span className="font-mono text-[10.5px] tracking-[0.11em] text-white/40 uppercase">
+        <span className="hidden font-mono text-[10.5px] tracking-[0.11em] text-white/40 uppercase sm:inline">
           Demo
         </span>
 
@@ -64,7 +70,7 @@ export default function Page() {
             own mono, and never competing with the wordmark — somebody who wants
             the docs or the source will look for them, and somebody who does not
             should not have three links in their way. */}
-        <nav className="ml-6 hidden items-center gap-5 sm:flex">
+        <nav className="ml-6 hidden items-center gap-5 md:flex">
           {NAV_LINKS.map((link) => (
             <a
               key={link.href}
@@ -80,7 +86,7 @@ export default function Page() {
 
         {/* The identity is in the chrome because it is the variable everything
             on screen depends on: this is one lawyer's estate, not the firm's. */}
-        <div className="ml-auto flex items-center gap-2.5">
+        <div className="ml-auto flex min-w-0 items-center gap-2 sm:gap-2.5">
           {/* The demo republishes the appliance's MCP server, and a lawyer
               connecting their own tool to it is a better demonstration than
               this page is — so the way in sits in the chrome, not in a doc. */}
@@ -89,7 +95,13 @@ export default function Page() {
           <span className="ml-1 hidden font-mono text-[10.5px] tracking-[0.11em] text-white/40 uppercase lg:inline">
             Signed in as
           </span>
-          <span className="rounded-full border border-white/15 bg-white/5 px-3 py-[5px] font-mono text-[11.5px] text-white/75">
+          {/* Truncated rather than wrapped or dropped: a firm's principal list
+              is longer than a phone is wide, and which identity this is stays
+              the one fact the bar cannot do without. */}
+          <span
+            title={identity}
+            className="max-w-[42vw] truncate rounded-full border border-white/15 bg-white/5 px-2.5 py-[5px] font-mono text-[11.5px] text-white/75 sm:max-w-none sm:px-3"
+          >
             {identity}
           </span>
           {/* Two different identities, deliberately not conflated. The pill is

--- a/demo/src/components/assistant-ui/markdown-text.tsx
+++ b/demo/src/components/assistant-ui/markdown-text.tsx
@@ -206,14 +206,19 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
+  // A table is the one thing an answer can contain that will not wrap. In a
+  // column the width of a phone it pushes the whole transcript sideways, so it
+  // scrolls inside its own box and the prose above it stays where it was.
   table: ({ className, ...props }) => (
-    <table
-      className={cn(
-        "aui-md-table my-3 w-full border-separate border-spacing-0 overflow-y-auto",
-        className,
-      )}
-      {...props}
-    />
+    <div className="aui-md-table-scroll my-3 w-full overflow-x-auto">
+      <table
+        className={cn(
+          "aui-md-table w-full border-separate border-spacing-0",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   ),
   th: ({ className, ...props }) => (
     <th

--- a/demo/src/components/auth-shell.tsx
+++ b/demo/src/components/auth-shell.tsx
@@ -46,26 +46,35 @@ export function AuthShell({
   children: ReactNode;
 }) {
   return (
-    <div className="flex min-h-full flex-col items-center justify-center bg-[var(--lm-black)] px-6 py-16">
-      <div className="flex w-full max-w-[420px] flex-col items-center">
-        <Wordmark />
+    // Two boxes rather than one, because the page behind this scrolls nowhere:
+    // the outer one is the viewport and owns the scrollbar, the inner one is at
+    // least a viewport tall so a short form sits centred. Centring the scroll
+    // container itself would put the top of a tall form — the wordmark, and on
+    // a phone in landscape the first field — above the top of the page, where
+    // there is no way to scroll back to it.
+    <div className="lm-scroll h-full overflow-y-auto bg-[var(--lm-black)]">
+      <div className="flex min-h-full flex-col items-center justify-center px-6 py-10 sm:py-16">
+        <div className="flex w-full max-w-[420px] flex-col items-center">
+          <Wordmark />
 
-        {/* This is not the product; it is an instance of it holding a synthetic
-            corpus. Saying so under the wordmark costs one line and prevents the
-            reading where someone signs in expecting their own firm's matters. */}
-        <span className="mt-3 rounded-full border border-white/15 bg-white/5 px-3 py-[5px] font-mono text-[10.5px] tracking-[0.11em] text-white/50 uppercase">
-          Demo
-        </span>
+          {/* This is not the product; it is an instance of it holding a
+              synthetic corpus. Saying so under the wordmark costs one line and
+              prevents the reading where someone signs in expecting their own
+              firm's matters. */}
+          <span className="mt-3 rounded-full border border-white/15 bg-white/5 px-3 py-[5px] font-mono text-[10.5px] tracking-[0.11em] text-white/50 uppercase">
+            Demo
+          </span>
 
-        <p className="mt-6 text-center text-[13.5px] leading-relaxed text-white/45">
-          {title}
-        </p>
+          <p className="mt-5 text-center text-[13.5px] leading-relaxed text-white/45 sm:mt-6">
+            {title}
+          </p>
 
-        <div className="mt-8 w-full">{children}</div>
+          <div className="mt-6 w-full sm:mt-8">{children}</div>
 
-        <p className="mt-10 text-center font-mono text-[10.5px] tracking-[0.08em] text-white/25 uppercase">
-          Eigenwelt Labs
-        </p>
+          <p className="mt-8 text-center font-mono text-[10.5px] tracking-[0.08em] text-white/25 uppercase sm:mt-10">
+            Eigenwelt Labs
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/demo/src/components/chat-panel.tsx
+++ b/demo/src/components/chat-panel.tsx
@@ -48,8 +48,11 @@ export function ChatPanel({ onReveal }: { onReveal: (documentId: string) => void
             Thread so the registration outlives any one message. */}
         <ToolCards />
         <div className="flex h-full min-h-0 flex-col bg-background">
-          <header className="flex flex-none items-baseline justify-between gap-3 border-b px-5 pt-4 pb-3.5">
-            <span className="lm-label">Ask</span>
+          <header className="compact:px-4 flex flex-none items-baseline justify-between gap-3 border-b px-5 pt-4 pb-3.5">
+            {/* The tab bar above this says Ask on a phone, and a heading is not
+                worth reading twice. What it says next to it is not repeated
+                anywhere, so that stays. */}
+            <span className="lm-label compact:hidden">Ask</span>
             <span className="lm-mono text-[10px] text-[var(--lm-muted-3)]">
               Answers cite the documents they came from
             </span>

--- a/demo/src/components/citations-card.tsx
+++ b/demo/src/components/citations-card.tsx
@@ -66,7 +66,9 @@ export function CitationsCard() {
               <span className="font-emphasis min-w-0 flex-1 truncate text-[13px] group-hover:text-[var(--lm-orange)]">
                 {document.title}
               </span>
-              <span className="lm-label shrink-0 opacity-0 transition-opacity duration-[var(--lm-dur-fast)] group-hover:opacity-100">
+              {/* The hint a pointer gets from hovering the row, spelled out
+                  where there is no pointer to hover with. */}
+              <span className="lm-label compact:opacity-100 shrink-0 opacity-0 transition-opacity duration-[var(--lm-dur-fast)] group-hover:opacity-100">
                 Open
               </span>
             </button>

--- a/demo/src/components/document-graph.tsx
+++ b/demo/src/components/document-graph.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { useCompact } from "@/lib/use-compact";
 import { cn } from "@/lib/utils";
 
 /**
@@ -35,11 +36,25 @@ export interface GraphNode {
   evidence?: string | null;
 }
 
-const WIDTH = 620;
-const HEIGHT = 360;
-// Enough to read the shape; past this, labels collide and the picture stops
-// being information. The card still says how many there are in total.
-const MAX_NODES = 9;
+/**
+ * The frame the graph is drawn in, and how much fits inside it.
+ *
+ * An SVG scales to the column it is given, and its type scales with it: this
+ * picture at 620 units wide, rendered into the 340 a phone has, is a correct
+ * drawing of the graph with six-pixel labels — which is a diagram of a diagram.
+ * So a narrow screen gets its own frame, roughly the width it will be drawn at,
+ * where eleven units is eleven pixels. Fewer nodes and shorter labels are what
+ * that frame will hold: past this they collide, and the card still says how many
+ * there are in total.
+ */
+const FRAME = {
+  wide: { width: 620, height: 360, nodes: 9, perLine: 26, rootPerLine: 34 },
+  // No rootPerLine: the hub's name is HTML above the picture at this size, and
+  // wraps to the card rather than to a line length guessed here.
+  compact: { width: 340, height: 400, nodes: 5, perLine: 17 },
+} as const;
+
+type Frame = (typeof FRAME)[keyof typeof FRAME];
 
 /** mulberry32 — small, seeded, and good enough for a layout. */
 function seeded(seed: number) {
@@ -73,10 +88,16 @@ interface Placed {
  * repulsion stops labels stacking. Sixty passes is well past the point where
  * this settles for the ten-odd nodes it ever draws.
  */
-function layout(count: number, seed: number): Placed[] {
+function layout(count: number, seed: number, frame: Frame): Placed[] {
+  const { width: WIDTH, height: HEIGHT } = frame;
   const random = seeded(seed);
   const centre = { x: WIDTH / 2, y: HEIGHT / 2 };
   const radius = Math.min(WIDTH, HEIGHT) * 0.36;
+
+  // The ring is drawn wider than it is tall because the frame is, and because
+  // labels need horizontal room. A frame taller than it is wide has neither
+  // reason, so it gets a circle.
+  const stretch = Math.max(1, (WIDTH / HEIGHT) * 0.78);
 
   const nodes: Placed[] = Array.from({ length: count }, (_, index) => {
     // A jittered ring, so the relaxation starts somewhere sane and the result
@@ -84,7 +105,7 @@ function layout(count: number, seed: number): Placed[] {
     const angle = (index / count) * Math.PI * 2 + random() * 0.7;
     const distance = radius * (0.78 + random() * 0.44);
     return {
-      x: centre.x + Math.cos(angle) * distance * 1.35,
+      x: centre.x + Math.cos(angle) * distance * stretch,
       y: centre.y + Math.sin(angle) * distance,
     };
   });
@@ -117,8 +138,11 @@ function layout(count: number, seed: number): Placed[] {
     }
   }
 
+  // Keep the label inside the frame, not the node: the disc is nine units wide
+  // and the name under it is as wide as the line it was wrapped to.
+  const inset = frame.perLine * 3.2;
   return nodes.map((node) => ({
-    x: Math.max(84, Math.min(WIDTH - 84, node.x)),
+    x: Math.max(inset, Math.min(WIDTH - inset, node.x)),
     y: Math.max(36, Math.min(HEIGHT - 56, node.y)),
   }));
 }
@@ -135,21 +159,40 @@ export function DocumentGraph({
   onReveal: (documentId: string) => void;
 }) {
   const [active, setActive] = useState<string | null>(null);
+  const compact = useCompact();
+  const frame = compact ? FRAME.compact : FRAME.wide;
+  const { width: WIDTH, height: HEIGHT } = frame;
 
-  const shown = useMemo(() => nodes.slice(0, MAX_NODES), [nodes]);
+  const shown = useMemo(() => nodes.slice(0, frame.nodes), [nodes, frame]);
   const positions = useMemo(
-    () => layout(shown.length, hash(rootTitle + shown.length)),
-    [shown, rootTitle],
+    () => layout(shown.length, hash(rootTitle + shown.length), frame),
+    [shown, rootTitle, frame],
   );
 
   const labels = useMemo(
-    () => shown.map((node) => wrapLabel(node.title, 26, 2)),
-    [shown],
+    () => shown.map((node) => wrapLabel(node.title, frame.perLine, 2)),
+    [shown, frame],
   );
 
   const centre = { x: WIDTH / 2, y: HEIGHT / 2 };
   const focused = shown.find((node) => node.documentId === active) ?? null;
   const storedCount = shown.filter((node) => node.stored).length;
+
+  /**
+   * Hovering is how this is read, and a touch screen has no hover.
+   *
+   * So on one, the first tap on a document says what the relation is and the
+   * second opens it — the caption is the half of the graph that carries the
+   * evidence, and going straight to the document skips it. With a pointer,
+   * hover has already said it and a click means open.
+   */
+  const activate = (documentId: string) => {
+    if (compact && active !== documentId) {
+      setActive(documentId);
+      return;
+    }
+    onReveal(documentId);
+  };
 
   return (
     <div className="bg-[var(--lm-paper-2)]">
@@ -158,6 +201,14 @@ export function DocumentGraph({
         <Legend swatch="var(--lm-orange)" label={`Relation ${storedCount}`} />
         <Legend swatch="var(--lm-muted-3)" label={`Context ${shown.length - storedCount}`} />
       </div>
+
+      {/* On a narrow frame the hub's name is the widest thing in the picture and
+          it sits in the middle of it, where the neighbours' own names are. Moved
+          up here it collides with nothing, wraps as text rather than as an SVG
+          label, and leaves the middle of a small graph to the graph. */}
+      {compact && (
+        <p className="font-emphasis px-3.5 pt-2.5 text-[12.5px] leading-snug">{rootTitle}</p>
+      )}
 
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
@@ -190,21 +241,24 @@ export function DocumentGraph({
           );
         })}
 
-        {/* The document itself: the orange hub, named beneath it. */}
+        {/* The document itself: the orange hub, named beneath it — or, on a
+            narrow frame, named above the picture instead. */}
         <circle cx={centre.x} cy={centre.y} r={19} fill="#E95700" />
-        <text
-          x={centre.x}
-          y={centre.y + 38}
-          textAnchor="middle"
-          className="fill-[var(--lm-ink-900)] text-[12.5px]"
-          style={{ fontWeight: 560 }}
-        >
-          {wrapLabel(rootTitle, 34, 2).map((line, lineIndex) => (
-            <tspan key={line + lineIndex} x={centre.x} dy={lineIndex === 0 ? 0 : 14}>
-              {line}
-            </tspan>
-          ))}
-        </text>
+        {!compact && (
+          <text
+            x={centre.x}
+            y={centre.y + 38}
+            textAnchor="middle"
+            className="fill-[var(--lm-ink-900)] text-[12.5px]"
+            style={{ fontWeight: 560 }}
+          >
+            {wrapLabel(rootTitle, FRAME.wide.rootPerLine, 2).map((line, lineIndex) => (
+              <tspan key={line + lineIndex} x={centre.x} dy={lineIndex === 0 ? 0 : 14}>
+                {line}
+              </tspan>
+            ))}
+          </text>
+        )}
 
         {shown.map((node, index) => {
           const point = positions[index];
@@ -212,14 +266,19 @@ export function DocumentGraph({
           return (
             <g
               key={node.documentId}
-              onMouseEnter={() => setActive(node.documentId)}
-              onMouseLeave={() => setActive(null)}
-              onClick={() => onReveal(node.documentId)}
+              // Pointer only: a browser sends these for a tap as well, and a
+              // node that "hovers" on the way to being tapped would open on the
+              // first tap, which is the behaviour `activate` exists to avoid.
+              onPointerEnter={(event) =>
+                event.pointerType === "mouse" && setActive(node.documentId)
+              }
+              onPointerLeave={(event) => event.pointerType === "mouse" && setActive(null)}
+              onClick={() => activate(node.documentId)}
               className="cursor-pointer"
             >
               {/* An invisible disc so the pointer target is comfortable without
                   drawing a node the size of the target. */}
-              <circle cx={point.x} cy={point.y} r={22} fill="transparent" />
+              <circle cx={point.x} cy={point.y} r={compact ? 26 : 22} fill="transparent" />
               <circle
                 cx={point.x}
                 cy={point.y}
@@ -266,8 +325,9 @@ export function DocumentGraph({
       </svg>
 
       {/* The caption is the graph's other half: an edge you cannot interrogate
-          is decoration. Hovering a node says what the relation is and, for a
-          stored one, the evidence the appliance recorded for it. */}
+          is decoration. Hovering a node — tapping it, without a pointer — says
+          what the relation is and, for a stored one, the evidence the appliance
+          recorded for it. */}
       <div className="min-h-[46px] border-t px-3.5 py-2.5">
         {focused ? (
           <>
@@ -279,14 +339,20 @@ export function DocumentGraph({
             >
               {focused.kind.replace(/_/g, " ")}
             </span>
+            {compact && (
+              <span className="lm-mono ml-2 text-[9.5px] tracking-[0.11em] text-[var(--lm-muted-3)] uppercase">
+                Tap again to open
+              </span>
+            )}
             <p className="mt-1 line-clamp-2 text-[11.5px] leading-[1.5] text-[var(--lm-muted-2)]">
               {focused.evidence ?? focused.title}
             </p>
           </>
         ) : (
           <p className="text-[11.5px] text-[var(--lm-muted-3)]">
-            {totalRelated > shown.length
-              ? `Showing ${shown.length} of ${totalRelated}. Hover for the relation, click to open.`
+            {totalRelated > shown.length ? `Showing ${shown.length} of ${totalRelated}. ` : ""}
+            {compact
+              ? "Tap a document for the relation, again to open it."
               : "Hover a document for the relation, click to open it."}
           </p>
         )}

--- a/demo/src/components/document-preview.tsx
+++ b/demo/src/components/document-preview.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, Download, FileQuestion, Loader2, X } from "lucide-react";
 
 import type { TreeFile } from "@/lib/appliance";
+import { useCompact } from "@/lib/use-compact";
 import { cn } from "@/lib/utils";
 import { EmlPreview } from "./eml-preview";
 import { PptxPreview } from "./pptx-preview";
@@ -76,9 +77,15 @@ export function DocumentPreview({ file, onClose }: { file: TreeFile; onClose: ()
 
 function PreviewHeader({ file, onClose }: { file: TreeFile; onClose: () => void }) {
   const href = `/api/preview?document_id=${encodeURIComponent(file.document_id)}&version_id=${encodeURIComponent(file.version_id)}`;
+  // Both are icons in a row with a filename that wants every pixel, so on a
+  // phone they grow into targets rather than the 24-pixel squares a pointer is
+  // happy with.
+  const action =
+    "flex-none rounded-lg border px-2.5 py-1.5 compact:px-3 compact:py-2.5 text-[var(--lm-muted-2)] transition-colors duration-[var(--lm-dur-fast)] hover:border-[rgba(233,87,0,0.35)] hover:text-[var(--lm-orange)]";
+
   return (
-    <header className="flex-none border-b px-5 pt-4 pb-3.5">
-      <div className="flex items-start gap-3">
+    <header className="compact:px-4 flex-none border-b px-5 pt-4 pb-3.5">
+      <div className="compact:gap-2 flex items-start gap-3">
         <FileGlyph mime={file.mime_type} name={file.name} className="mt-[3px] size-4" />
         <div className="min-w-0 flex-1">
           <h2 className="font-emphasis truncate text-[15px]">{file.title || file.name}</h2>
@@ -86,12 +93,7 @@ function PreviewHeader({ file, onClose }: { file: TreeFile; onClose: () => void 
             {file.path}
           </p>
         </div>
-        <a
-          href={href}
-          download={file.name}
-          className="flex-none rounded-lg border px-2.5 py-1.5 text-[var(--lm-muted-2)] transition-colors duration-[var(--lm-dur-fast)] hover:border-[rgba(233,87,0,0.35)] hover:text-[var(--lm-orange)]"
-          title="Download the original"
-        >
+        <a href={href} download={file.name} className={action} title="Download the original">
           <Download className="size-3.5" />
         </a>
         <button
@@ -99,7 +101,7 @@ function PreviewHeader({ file, onClose }: { file: TreeFile; onClose: () => void 
           onClick={onClose}
           title="Close the preview"
           aria-label="Close the preview"
-          className="flex-none rounded-lg border px-2.5 py-1.5 text-[var(--lm-muted-2)] transition-colors duration-[var(--lm-dur-fast)] hover:border-[rgba(233,87,0,0.35)] hover:text-[var(--lm-orange)]"
+          className={action}
         >
           <X className="size-3.5" />
         </button>
@@ -135,7 +137,7 @@ function PreviewBody({ file }: { file: TreeFile }) {
       return <iframe src={src} title={file.name} className="h-full w-full border-0 bg-white" />;
     case "image":
       return (
-        <div className="flex min-h-full items-center justify-center p-6">
+        <div className="compact:p-3 flex min-h-full items-center justify-center p-6">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={src} alt={file.name} className="max-h-full max-w-full object-contain shadow-sm" />
         </div>
@@ -201,6 +203,7 @@ function DocxPreview({ src }: { src: string }) {
   const host = useRef<HTMLDivElement>(null);
   const { status, buffer, error } = useBytes(src);
   const [rendering, setRendering] = useState(false);
+  const compact = useCompact();
 
   useEffect(() => {
     if (status !== "ready" || !buffer || !host.current) return;
@@ -214,8 +217,14 @@ function DocxPreview({ src }: { src: string }) {
         renderAsync(buffer, target, undefined, {
           className: "docx",
           inWrapper: true,
-          ignoreWidth: false,
-          ignoreHeight: false,
+          // A Word page is 21 centimetres wide and a phone is seven. Laid out
+          // at its own width it becomes a document you read by dragging
+          // sideways a line at a time, so on a small screen the text is
+          // reflowed to the pane instead — and the page height has to go with
+          // it, or the extra lines that reflowing produces are simply clipped
+          // at the bottom of a page that is still A4 tall.
+          ignoreWidth: compact,
+          ignoreHeight: compact,
           // Word's own numbering and fonts, so a numbered contract keeps its
           // clause numbers — which is most of what makes a preview citable.
           experimental: true,
@@ -229,12 +238,12 @@ function DocxPreview({ src }: { src: string }) {
       cancelled = true;
       target.replaceChildren();
     };
-  }, [buffer, status]);
+  }, [buffer, compact, status]);
 
   if (status === "loading") return <Busy label="Loading document" />;
   if (status === "error") return <Failed message={error} />;
   return (
-    <div className="p-6">
+    <div className="compact:p-3 p-6">
       {rendering && <Busy label="Laying out" />}
       <div ref={host} className="docx-host [&_.docx-wrapper]:!bg-transparent [&_.docx-wrapper]:!p-0 [&_section.docx]:!mb-6 [&_section.docx]:!shadow-sm" />
     </div>
@@ -297,7 +306,7 @@ function SheetPreview({ src, name }: { src: string; name: string }) {
           ))}
         </div>
       )}
-      <div className="lm-scroll min-h-0 flex-1 overflow-auto p-5">
+      <div className="lm-scroll compact:p-3 min-h-0 flex-1 overflow-auto p-5">
         <div
           className={cn(
             "w-fit min-w-full overflow-hidden rounded-xl border bg-background",
@@ -330,8 +339,8 @@ function TextPreview({ src }: { src: string }) {
   if (error) return <Failed message={error} />;
   if (text === null) return <Busy label="Loading" />;
   return (
-    <div className="p-5">
-      <pre className="lm-mono rounded-xl border bg-background p-5 text-[12px] leading-[1.65] whitespace-pre-wrap">
+    <div className="compact:p-3 p-5">
+      <pre className="lm-mono compact:p-4 rounded-xl border bg-background p-5 text-[12px] leading-[1.65] whitespace-pre-wrap">
         {text}
       </pre>
     </div>
@@ -373,7 +382,7 @@ function ConvertedText({ file, fallbackNotice }: { file: TreeFile; fallbackNotic
   if (!state) return <Busy label="Loading text" />;
 
   return (
-    <div className="p-5">
+    <div className="compact:p-3 p-5">
       <div className="mb-3 flex items-center gap-2 rounded-lg border border-[rgba(233,87,0,0.22)] bg-[rgba(233,87,0,0.05)] px-3 py-2">
         <FileQuestion className="size-3.5 shrink-0 text-[var(--lm-orange)]" />
         <p className="text-[12px] text-[var(--lm-fg2)]">
@@ -384,7 +393,7 @@ function ConvertedText({ file, fallbackNotice }: { file: TreeFile; fallbackNotic
           above to see the file itself.
         </p>
       </div>
-      <pre className="rounded-xl border bg-background p-5 text-[13px] leading-[1.7] whitespace-pre-wrap">
+      <pre className="compact:p-4 rounded-xl border bg-background p-5 text-[13px] leading-[1.7] whitespace-pre-wrap">
         {state.text || "This document has no extracted text."}
       </pre>
       {state.more && (

--- a/demo/src/components/eml-preview.tsx
+++ b/demo/src/components/eml-preview.tsx
@@ -286,9 +286,9 @@ export function EmlPreview({ src }: { src: string }) {
   const body = email.text ?? (email.html ? null : email.raw);
 
   return (
-    <div className="p-5">
+    <div className="compact:p-3 p-5">
       <article className="overflow-hidden rounded-xl border bg-background">
-        <header className="border-b px-5 py-4">
+        <header className="compact:px-4 border-b px-5 py-4">
           <h3 className="font-emphasis text-[15px] leading-snug">
             {headers.subject || "(no subject)"}
           </h3>
@@ -313,7 +313,7 @@ export function EmlPreview({ src }: { src: string }) {
           )}
         </header>
 
-        <div className="px-5 py-4">
+        <div className="compact:px-4 px-5 py-4">
           {showSource ? (
             <pre className="lm-mono text-[11.5px] leading-[1.6] whitespace-pre-wrap">
               {email.raw}
@@ -325,7 +325,7 @@ export function EmlPreview({ src }: { src: string }) {
               srcDoc={email.html}
               title={headers.subject || "message"}
               sandbox=""
-              className="h-[60vh] w-full border-0"
+              className="h-[60dvh] w-full border-0"
             />
           ) : (
             <pre className="text-[13px] leading-[1.7] whitespace-pre-wrap">
@@ -334,7 +334,7 @@ export function EmlPreview({ src }: { src: string }) {
           )}
         </div>
 
-        <footer className="flex justify-end border-t px-5 py-2.5">
+        <footer className="compact:px-4 compact:py-3.5 flex justify-end border-t px-5 py-2.5">
           <button
             type="button"
             onClick={() => setShowSource((current) => !current)}

--- a/demo/src/components/file-tree.tsx
+++ b/demo/src/components/file-tree.tsx
@@ -5,6 +5,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, Search, X } from "lucide-react";
 
 import type { TreeFile, TreeFolder, TreePage, TreeRoot } from "@/lib/appliance";
+import { useCompact } from "@/lib/use-compact";
 import { cn } from "@/lib/utils";
 import { FileGlyph } from "./file-glyph";
 
@@ -24,7 +25,12 @@ import { FileGlyph } from "./file-glyph";
  */
 
 const PAGE_SIZE = 200;
+// Thirty pixels is a dense list to read with a mouse and a hard target to hit
+// with a thumb. The virtualizer measures what it renders, but its estimate has
+// to be the height being rendered or a reveal scrolls to the wrong place in a
+// folder of ten thousand files.
 const ROW_HEIGHT = 30;
+const TOUCH_ROW_HEIGHT = 40;
 const INDENT = 15;
 
 type NodeKey = string;
@@ -75,6 +81,8 @@ interface FileTreeProps {
 }
 
 export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
+  const compact = useCompact();
+  const rowHeight = compact ? TOUCH_ROW_HEIGHT : ROW_HEIGHT;
   const [roots, setRoots] = useState<TreeRoot[] | null>(null);
   const [rootsError, setRootsError] = useState<string | null>(null);
   const [open, setOpen] = useState<Set<NodeKey>>(new Set());
@@ -372,10 +380,16 @@ export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => ROW_HEIGHT,
+    estimateSize: () => rowHeight,
     overscan: 14,
     getItemKey: (index) => rows[index].key,
   });
+
+  // Rows change height when the screen crosses into touch sizing, and every
+  // measurement above the viewport is now wrong by ten pixels each.
+  useEffect(() => {
+    virtualizer.measure();
+  }, [rowHeight, virtualizer]);
 
   // Scroll a revealed file into view once its row is in the list.
   //
@@ -418,7 +432,11 @@ export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
             placeholder="Search filenames"
             aria-label="Search filenames"
             className={cn(
-              "h-8 w-full rounded-lg border bg-[var(--lm-paper-2)] pr-7 pl-8 text-[13px]",
+              "h-8 w-full rounded-lg border bg-[var(--lm-paper-2)] pr-9 pl-8 text-[13px]",
+              // Sixteen pixels on a phone is not a type choice: Safari zooms
+              // into any field it is asked to focus below it, and comes back
+              // out somewhere else in the tree.
+              "compact:h-10 compact:text-[16px]",
               "placeholder:text-[var(--lm-muted-3)]",
               "focus:border-[rgba(233,87,0,0.4)] focus:bg-background focus:ring-2 focus:ring-[var(--ring)] focus:outline-none",
               "transition-[background-color,border-color] duration-[var(--lm-dur-fast)]",
@@ -429,7 +447,7 @@ export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
               type="button"
               onClick={() => setQuery("")}
               aria-label="Clear search"
-              className="absolute top-1/2 right-2 -translate-y-1/2 text-[var(--lm-muted-3)] hover:text-foreground"
+              className="compact:p-2.5 absolute top-1/2 right-1 -translate-y-1/2 p-1.5 text-[var(--lm-muted-3)] hover:text-foreground"
             >
               <X className="size-3.5" />
             </button>
@@ -451,6 +469,7 @@ export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
               >
                 <TreeRow
                   row={row}
+                  height={rowHeight}
                   selectedId={selected?.source_object_id ?? null}
                   onToggle={toggle}
                   onSelect={onSelect}
@@ -470,6 +489,7 @@ export function FileTree({ selected, onSelect, onReady }: FileTreeProps) {
 
 interface TreeRowProps {
   row: Row;
+  height: number;
   selectedId: string | null;
   showPath: boolean;
   onToggle: (sourceId: string, path: string) => void;
@@ -477,14 +497,22 @@ interface TreeRowProps {
   onLoadMore: (sourceId: string, path: string, offset: number) => void;
 }
 
-function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: TreeRowProps) {
-  const pad = { paddingLeft: 10 + row.depth * INDENT };
+function TreeRow({
+  row,
+  height,
+  selectedId,
+  showPath,
+  onToggle,
+  onSelect,
+  onLoadMore,
+}: TreeRowProps) {
+  const pad = { height, paddingLeft: 10 + row.depth * INDENT };
 
   if (row.kind === "status") {
     return (
       <div
         style={pad}
-        className="flex h-[30px] items-center gap-2 pr-3 text-[12px] text-[var(--lm-muted-3)]"
+        className="flex items-center gap-2 pr-3 text-[12px] text-[var(--lm-muted-3)]"
       >
         {row.spinning && <Loader2 className="size-3 animate-spin" />}
         <span className="truncate">{row.label}</span>
@@ -498,7 +526,7 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
         type="button"
         style={pad}
         onClick={() => onLoadMore(row.sourceId, row.path, row.loaded)}
-        className="flex h-[30px] w-full items-center pr-3 text-left text-[12px] text-[var(--lm-orange)] hover:underline"
+        className="flex w-full items-center pr-3 text-left text-[12px] text-[var(--lm-orange)] hover:underline"
       >
         {/* The count is the honest version of an infinite scroll: a folder with
             nine thousand more files in it should say so. */}
@@ -518,7 +546,7 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
         data-root={row.root.source_id}
         aria-expanded={row.open}
         onClick={() => onToggle(row.root.source_id, "")}
-        className="group flex h-[30px] w-full items-center gap-1.5 pr-3 text-left hover:bg-[var(--lm-paper-2)]"
+        className="group flex w-full items-center gap-1.5 pr-3 text-left hover:bg-[var(--lm-paper-2)]"
       >
         <ChevronRight
           className={cn(
@@ -544,7 +572,7 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
         data-folder={row.folder.path}
         aria-expanded={row.open}
         onClick={() => onToggle(row.sourceId, row.folder.path)}
-        className="group flex h-[30px] w-full items-center gap-1.5 pr-3 text-left hover:bg-[var(--lm-paper-2)]"
+        className="group flex w-full items-center gap-1.5 pr-3 text-left hover:bg-[var(--lm-paper-2)]"
       >
         <ChevronRight
           className={cn(
@@ -553,7 +581,10 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
           )}
         />
         <span className="truncate text-[13px] text-foreground">{row.folder.name}</span>
-        <span className="lm-mono ml-auto shrink-0 text-[10px] text-[var(--lm-muted-3)] opacity-0 tabular-nums group-hover:opacity-100">
+        {/* Kept for a pointer, shown outright without one: there is no hover on
+            a touch screen, and a count nobody can reveal is a count nobody
+            has. */}
+        <span className="lm-mono compact:opacity-100 ml-auto shrink-0 text-[10px] text-[var(--lm-muted-3)] opacity-0 tabular-nums group-hover:opacity-100">
           {row.folder.files.toLocaleString()}
         </span>
       </button>
@@ -569,7 +600,7 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
       onClick={() => onSelect(row.file)}
       title={row.file.path}
       className={cn(
-        "group relative flex h-[30px] w-full items-center gap-1.5 pr-3 text-left",
+        "group relative flex w-full items-center gap-1.5 pr-3 text-left",
         "transition-colors duration-[var(--lm-dur-fast)]",
         active ? "bg-[rgba(233,87,0,0.08)]" : "hover:bg-[var(--lm-paper-2)]",
       )}
@@ -591,8 +622,10 @@ function TreeRow({ row, selectedId, showPath, onToggle, onSelect, onLoadMore }: 
       >
         {row.file.name}
       </span>
+      {/* The path is context for the name; on a narrow screen it takes less of
+          the row, because the name is the part being read and tapped. */}
       {showPath && (
-        <span className="lm-mono ml-auto max-w-[45%] shrink-0 truncate pl-2 text-[10px] text-[var(--lm-muted-3)]">
+        <span className="lm-mono compact:max-w-[36%] ml-auto max-w-[45%] shrink-0 truncate pl-2 text-[10px] text-[var(--lm-muted-3)]">
           {row.file.path}
         </span>
       )}

--- a/demo/src/components/mcp-modal.tsx
+++ b/demo/src/components/mcp-modal.tsx
@@ -40,19 +40,25 @@ export function McpModal({ authEnabled }: { authEnabled: boolean }) {
       <DialogTrigger asChild>
         <button
           type="button"
+          // The label is the whole point of the button on a desktop and is the
+          // widest thing in the bar on a phone, where the plug says it well
+          // enough to be worth a tap.
+          aria-label="Test with MCP"
           className={cn(
-            "flex items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-[5px]",
+            "flex items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-2.5 py-[7px] sm:px-3 sm:py-[5px]",
             "font-mono text-[10.5px] tracking-[0.11em] text-white/70 uppercase",
             "transition-colors duration-[var(--lm-dur-fast)]",
             "hover:border-[rgba(233,87,0,0.5)] hover:text-[var(--lm-orange-hi)]",
           )}
         >
           <Plug className="size-3" aria-hidden />
-          Test with MCP
+          <span className="hidden sm:inline">Test with MCP</span>
         </button>
       </DialogTrigger>
 
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+      {/* `dvh`, because `vh` on a phone is measured against a viewport with the
+          address bar hidden — which it is not, so the dialog runs off-screen. */}
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
           <DialogTitle className="text-[17px] tracking-[-0.035em]">
             Connect your own tools
@@ -196,7 +202,9 @@ function CopyRow({ value, multiline }: { value: string; multiline?: boolean }) {
       <code
         className={cn(
           "lm-mono min-w-0 flex-1 text-[11.5px] leading-[1.6] text-[var(--lm-ink-900)]",
-          multiline ? "whitespace-pre-wrap" : "truncate",
+          // A URL is one long word: on a phone `pre-wrap` alone keeps it on one
+          // line and pushes the copy button off the card.
+          multiline ? "break-words whitespace-pre-wrap" : "truncate",
         )}
       >
         {value}

--- a/demo/src/components/welcome-heading.tsx
+++ b/demo/src/components/welcome-heading.tsx
@@ -29,19 +29,25 @@ export function WelcomeHeading() {
     };
   }, []);
 
+  // Smaller on a small screen, and not for taste: this sits above the composer
+  // and the openers, and at display size in a phone's landscape it pushes both
+  // of them off the bottom of the screen.
   return (
-    <div className="mb-6 flex flex-col items-center px-4 text-center">
-      <h1 className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-[34px] leading-[1.05] font-semibold tracking-[-0.045em] duration-200">
+    <div className="compact:mb-4 mb-6 flex flex-col items-center px-4 text-center">
+      <h1 className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both compact:text-[26px] text-[34px] leading-[1.05] font-semibold tracking-[-0.045em] duration-200">
         LegalMemory Demo
       </h1>
-      <p className="mt-3 max-w-md text-[15px] leading-relaxed text-[var(--lm-muted-2)]">
+      <p className="compact:mt-2 compact:text-[14px] mt-3 max-w-md text-[15px] leading-relaxed text-[var(--lm-muted-2)]">
         {/* No skeleton and no jump: until the count arrives the sentence still
             reads, and the number slots into a gap the layout already had. */}
         Ask anything about the{" "}
         <span className="font-emphasis text-foreground tabular-nums">
           {count === null ? "" : count.toLocaleString()}
         </span>{" "}
-        documents on the left.
+        {/* Where the documents are depends on the screen: beside this on a
+            desktop, behind the tab next to it on a phone. Naming a direction
+            that is not there is worse than not pointing at all. */}
+        documents<span className="compact:hidden"> on the left</span>.
       </p>
     </div>
   );

--- a/demo/src/components/workspace.tsx
+++ b/demo/src/components/workspace.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 
 import type { TreeFile } from "@/lib/appliance";
+import { cn } from "@/lib/utils";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -19,64 +20,171 @@ import { FileTree, type FileTreeHandle } from "./file-tree";
  * selected — and one action: reveal. An answer citing a document and a click in
  * the tree end in the same place, which is what makes the citations feel like
  * part of the file browser rather than a footnote next to it.
+ *
+ * Below the compact breakpoint the same three panels become tabs. They are not
+ * rebuilt for it: the CSS in globals.css lays them on top of each other and
+ * shows the one named by `data-active`, so switching tabs costs nothing and a
+ * phone turned sideways does not throw away the conversation. Which is why the
+ * tab bar is the only thing here that knows about screen size — everything
+ * else is the same component on both.
  */
+
+type Pane = "tree" | "preview" | "chat";
+
 export function Workspace() {
   const [selected, setSelected] = useState<TreeFile | null>(null);
+  // Ignored entirely on a wide screen, where all three panels are on show. The
+  // chat is where a visitor starts: the openers are the invitation, and the
+  // tree is one tab away rather than in front of the thing to do.
+  const [pane, setPane] = useState<Pane>("chat");
+  // The tab the current document was opened from, so closing it goes back where
+  // the reader was — the tree if they were browsing, the chat if they followed
+  // a citation — rather than to whichever tab we picked as a default.
+  const cameFrom = useRef<Pane>("chat");
   const tree = useRef<FileTreeHandle | null>(null);
 
   const onReady = useCallback((handle: FileTreeHandle) => {
     tree.current = handle;
   }, []);
 
+  const select = useCallback(
+    (file: TreeFile) => {
+      setSelected(file);
+      if (pane !== "preview") cameFrom.current = pane;
+      setPane("preview");
+    },
+    [pane],
+  );
+
+  const close = useCallback(() => {
+    setSelected(null);
+    setPane(cameFrom.current);
+  }, []);
+
   // The tree owns revealing, because it owns which folders are open and where
-  // the scroll is. This hands the id over and lets it do that.
+  // the scroll is. This hands the id over and lets it do that; the tree calls
+  // `select` with what it found, which brings the document to the front.
   const reveal = useCallback((documentId: string) => {
     void tree.current?.reveal(documentId);
   }, []);
 
+  // A tab that is not on screen cannot be the open one. Nothing should reach
+  // this — closing the preview picks a tab — but a blank screen is the failure
+  // mode if something ever does.
+  const active: Pane = pane === "preview" && !selected ? "chat" : pane;
+
   return (
-    // Sizes are strings: react-resizable-panels v4 reads a bare number as
-    // pixels, so `defaultSize={22}` would be a 22-pixel sidebar.
-    //
-    // Panels carry stable ids so the group tracks them across the preview
-    // opening and closing. Keying the group instead would remount it — and with
-    // it the tree, which would lose every folder the user had opened the moment
-    // they clicked a file in one.
-    <ResizablePanelGroup orientation="horizontal" className="h-full">
-      <ResizablePanel
-        id="tree"
-        defaultSize={selected ? "22" : "26"}
-        minSize="15"
-        maxSize="40"
-        className="min-w-0"
-      >
-        <FileTree selected={selected} onSelect={setSelected} onReady={onReady} />
-      </ResizablePanel>
+    <div className="flex h-full min-h-0 flex-col">
+      <PaneTabs active={active} hasPreview={Boolean(selected)} onSelect={setPane} />
 
-      <ResizableHandle className="bg-[var(--lm-line)] transition-colors duration-[var(--lm-dur-fast)] hover:bg-[rgba(233,87,0,0.35)]" />
+      {/* Sizes are strings: react-resizable-panels v4 reads a bare number as
+          pixels, so `defaultSize={22}` would be a 22-pixel sidebar.
 
-      {/* The preview exists only once there is something to preview. An empty
-          third of the screen holding a placeholder is a worse answer to "what
-          is this application" than two columns that do their jobs, and the
-          chat and tree are both better for the room. */}
-      {selected && (
-        <>
-          <ResizablePanel id="preview" defaultSize="46" minSize="25" className="min-w-0">
-            <DocumentPreview file={selected} onClose={() => setSelected(null)} />
-          </ResizablePanel>
+          Panels carry stable ids so the group tracks them across the preview
+          opening and closing. Keying the group instead would remount it — and
+          with it the tree, which would lose every folder the user had opened
+          the moment they clicked a file in one. */}
+      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+        <ResizablePanel
+          id="tree"
+          data-active={active === "tree" || undefined}
+          defaultSize={selected ? "22" : "26"}
+          minSize="15"
+          maxSize="40"
+          className="min-w-0"
+        >
+          <FileTree selected={selected} onSelect={select} onReady={onReady} />
+        </ResizablePanel>
 
-          <ResizableHandle className="bg-[var(--lm-line)] transition-colors duration-[var(--lm-dur-fast)] hover:bg-[rgba(233,87,0,0.35)]" />
-        </>
-      )}
+        <ResizableHandle className="bg-[var(--lm-line)] transition-colors duration-[var(--lm-dur-fast)] hover:bg-[rgba(233,87,0,0.35)]" />
 
-      <ResizablePanel
-        id="chat"
-        defaultSize={selected ? "32" : "74"}
-        minSize="22"
-        className="min-w-0"
-      >
-        <ChatPanel onReveal={reveal} />
-      </ResizablePanel>
-    </ResizablePanelGroup>
+        {/* The preview exists only once there is something to preview. An empty
+            third of the screen holding a placeholder is a worse answer to "what
+            is this application" than two columns that do their jobs, and the
+            chat and tree are both better for the room. */}
+        {selected && (
+          <>
+            <ResizablePanel
+              id="preview"
+              data-active={active === "preview" || undefined}
+              defaultSize="46"
+              minSize="25"
+              className="min-w-0"
+            >
+              <DocumentPreview file={selected} onClose={close} />
+            </ResizablePanel>
+
+            <ResizableHandle className="bg-[var(--lm-line)] transition-colors duration-[var(--lm-dur-fast)] hover:bg-[rgba(233,87,0,0.35)]" />
+          </>
+        )}
+
+        <ResizablePanel
+          id="chat"
+          data-active={active === "chat" || undefined}
+          defaultSize={selected ? "32" : "74"}
+          minSize="22"
+          className="min-w-0"
+        >
+          <ChatPanel onReveal={reveal} />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}
+
+/**
+ * The three panels, as tabs, on a screen that holds one of them.
+ *
+ * Named for what each panel calls itself — the tree's header says Documents and
+ * the chat's says Ask — so the tab and the header a tap away are the same word.
+ * The middle tab appears with the document and leaves with it: a tab that opens
+ * an empty pane is a tab that should not be there.
+ */
+function PaneTabs({
+  active,
+  hasPreview,
+  onSelect,
+}: {
+  active: Pane;
+  hasPreview: boolean;
+  onSelect: (pane: Pane) => void;
+}) {
+  const tabs: Array<{ id: Pane; label: string }> = [
+    { id: "tree", label: "Documents" },
+    ...(hasPreview ? [{ id: "preview" as const, label: "Preview" }] : []),
+    { id: "chat", label: "Ask" },
+  ];
+
+  return (
+    <nav
+      aria-label="Panels"
+      className="compact:flex hidden flex-none items-stretch border-b bg-background"
+    >
+      {tabs.map((tab) => {
+        const current = tab.id === active;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onSelect(tab.id)}
+            aria-current={current ? "true" : undefined}
+            className={cn(
+              "relative h-11 flex-1 font-mono text-[10px] tracking-[0.11em] uppercase",
+              "transition-colors duration-[var(--lm-dur-fast)]",
+              current ? "text-foreground" : "text-[var(--lm-muted-3)]",
+            )}
+          >
+            {tab.label}
+            {/* The one mark of orange on this bar, on the one thing it names. */}
+            {current && (
+              <span
+                className="absolute inset-x-0 bottom-0 h-[2px] bg-[var(--lm-orange)]"
+                aria-hidden
+              />
+            )}
+          </button>
+        );
+      })}
+    </nav>
   );
 }

--- a/demo/src/lib/use-compact.ts
+++ b/demo/src/lib/use-compact.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * One definition of "too small for three columns".
+ *
+ * Narrow, or short and not wide: a phone in portrait is the first case, a phone
+ * in landscape the second — 844 by 390 is wide enough for three columns and has
+ * nowhere near the height to read a document in one. The second clause stops
+ * below tablet width so a laptop with the devtools open keeps its columns.
+ *
+ * The same query is a Tailwind variant in globals.css, spelled identically.
+ * Everything that can be done in CSS is done there — this is for the handful of
+ * decisions that are not styling: how many nodes a graph draws, whether a Word
+ * file is laid out at its own page width or reflowed to the pane.
+ */
+export const COMPACT_MEDIA =
+  "(max-width: 767.98px), (max-width: 1023.98px) and (max-height: 599.98px)";
+
+let query: MediaQueryList | null = null;
+const list = () => (query ??= window.matchMedia(COMPACT_MEDIA));
+
+function subscribe(onChange: () => void) {
+  const media = list();
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+}
+
+/**
+ * The server has no viewport, so it renders the wide layout and the first client
+ * render agrees with it; the effect after hydration corrects a phone. Nothing
+ * that decides page structure reads this — the structure is CSS — so the
+ * correction costs a second render of a graph, not a flash of the wrong screen.
+ */
+export const useCompact = () =>
+  useSyncExternalStore(
+    subscribe,
+    () => list().matches,
+    () => false,
+  );


### PR DESCRIPTION
The demo was a fixed horizontal split at every width, so on a phone the tree was sixty pixels wide and the chat could not hold a sentence.

## The layout

Below a compact breakpoint the three panels become tabs — **Documents · Preview · Ask** — and they are the same three panels: the CSS in `globals.css` lays them over each other and shows the one carrying `data-active`.

Nothing is rebuilt when the breakpoint is crossed, which is the reason this is CSS and not a second React tree. A phone turned sideways, or a window dragged across the breakpoint, would otherwise remount the chat and throw the conversation away. `visibility` rather than `display` for the same reason one level down: a hidden pane keeps its layout, so the tree stays scrolled where it was and the transcript does not jump to the top every time somebody looks at a document.

Selecting a document brings its tab forward; closing it goes back where the reader was — the tree if they were browsing, the chat if they followed a citation.

The breakpoint is *narrow, or short and not wide*: a phone in landscape has the width for three columns and nowhere near the height to read a document in one. It is written once as a Tailwind variant and once, identically, as a media query in `src/lib/use-compact.ts` for the few decisions styling cannot make.

## The rest of what a phone needs

- The body is sized in `dvh` and the viewport declares `interactive-widget=resizes-content`, so the composer sits above the keyboard instead of under it.
- Tree rows are 40px and the filename search field is 16px — below that, Safari zooms the page on focus and lands somewhere else in the tree.
- A Word file is reflowed to the pane rather than laid out at the width of a page nobody can read sideways.
- The document graph is redrawn in a frame the width it will actually be rendered at; a 620-unit picture in 340 pixels is a correct drawing with six-pixel labels. Without a pointer to hover with, the first tap on a node says what the relation is and the second opens it.
- Markdown tables scroll inside their own box instead of pushing the transcript sideways.
- The header keeps the wordmark, the way into MCP and the identity, and drops the signposts (eyebrow, divider, the three links out).
- The sign-in page scrolls instead of being clipped by a body that does not.

Nothing about the wide layout changes.

## Verification

`tsc`, `eslint` and `next build` are clean. Nine viewports were driven in Chromium (iPhone portrait and landscape, tablet, desktop) against a mock appliance: zero horizontal page overflow and no console errors on any of them, plus fourteen interaction assertions — tab switching, the preview opening on select and closing back to its origin, the composer text and the tree's open folders surviving a breakpoint cross, row height, field size. All passing.

Screenshots ran against a stub of the appliance's tree and MCP endpoints, so the corpus in any screenshot is synthetic; none of that scaffolding is in the diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GiRiysL8qBPDoBYxEWf1zp)_