### PR TITLE
Fix two silent failure modes in corpus loading, and document the rest

### DIFF
--- a/deploy/README-hosted-demo.md
+++ b/deploy/README-hosted-demo.md
@@ -83,7 +83,83 @@ answer before reporting success.
 
 ## Loading the index
 
-The stack starts empty. To load a corpus, restore a dump into the `postgres`
-service and rebuild the search index from the embeddings the dump already
-carries — no re-embedding required, since `chunks.embedding` is populated and
-`OpenSearchIndex.bulk_sync` reads it rather than recomputing.
+The stack starts empty. A corpus lives in two stores, and only one of them
+travels in a database dump:
+
+| Store | Holds | Travels as |
+|---|---|---|
+| Postgres | documents, chunks, metadata, **and the embedding vector per chunk** | `pg_dump --format=custom` |
+| OpenSearch | a copy of each chunk's text and vector — what queries actually hit | its own snapshot, or a rebuild |
+
+So restoring a dump leaves search returning nothing until the index is
+populated, by one of two routes:
+
+* **Restore an OpenSearch snapshot** of the source index, if you have one and the
+  clusters are the same major version. It is a file copy — minutes.
+* **Rebuild from `chunks.embedding`** with `deploy/reindex_from_embeddings.py`.
+  No re-embedding and no token spend, since the dump already carries the vectors
+  and `OpenSearchIndex.bulk_sync` reads them rather than recomputing. Budget
+  roughly an hour per few million chunks on an 8-vCPU host.
+
+### Check the embeddings first — the index name will not warn you
+
+The index name is derived from the embedding *signature*, which keys on vector
+**width**, not on which model produced the vectors. Two different models at the
+same width therefore resolve to the same index name. Load a corpus embedded by
+model A into a deployment that embeds queries with model B and every step
+succeeds — restore, reindex, healthchecks green — while dense retrieval compares
+query vectors against document vectors from a different model and returns
+confident nonsense.
+
+Two things must line up, and both are silent when they do not:
+
+1. **The model.** `KI_EMBEDDING_MODEL` / `KI_EMBEDDING_UPSTREAM` must name the
+   model the corpus was embedded with.
+2. **The width.** Some models emit wider vectors than the index expects and must
+   be truncated back — `dimensions:` in the embedding block of
+   `deploy/litellm/demo-config.yaml`, which LiteLLM maps onto the provider's own
+   parameter (Gemini's `output_dimensionality`, for instance). There is no
+   environment variable for it, so copying `KI_EMBEDDING_*` across from wherever
+   the corpus was built is *not* sufficient.
+
+Ask the provider how wide its vectors actually are before loading anything, and
+compare against the width the index was built at:
+
+```bash
+docker compose exec -T postgres psql -U ki -d ki -Atc \
+  "SELECT vector_dims(embedding) FROM chunks WHERE embedding IS NOT NULL LIMIT 1;"
+```
+
+Also confirm `alembic_version` in the dump matches the appliance you are loading
+it into, and — if the corpus came from a deployment with connectors configured —
+that `source_credentials` is empty, since those rows are encrypted with the
+*source's* `KI_CONNECTOR_CREDENTIAL_KEY` and are undecryptable anywhere else.
+
+### Replacing a corpus that is already live
+
+Back up first. Both halves can be captured without stopping anything: `pg_dump`
+takes an MVCC-consistent snapshot, and the OpenSearch snapshot API does not need
+the node quiesced. Verify what you wrote rather than trusting it — a session
+killed mid-archive leaves a plausible file of roughly the right size — and keep
+the OpenSearch snapshot, because it makes a rollback a restore rather than
+another rebuild.
+
+Then keep the outage down to the index step:
+
+* Restore the incoming dump into a **side database** (`ki_new`) while the current
+  one keeps serving, then cut over with two `ALTER DATABASE ... RENAME`s. Renaming
+  the old database aside rather than dropping it is what makes the rollback cheap.
+* Stage the new index as a snapshot ahead of time, so the cutover restores it
+  instead of rebuilding it.
+* Note that `docker cp`-ing a large dump into the postgres container needs it on
+  disk twice; bind-mount the staging directory into a throwaway client container
+  on the compose network and restore over TCP instead.
+
+Restoring a snapshot still needs the target index name free, which is the one
+irreducible piece of downtime. To remove it, restore into a differently named
+index and have the app's index name be an **alias** pointing at it: an alias flip
+is atomic, and the cost is only the disk to hold both indexes while you switch.
+
+Afterwards, free the staged snapshot. OpenSearch stops allocating shards at 90%
+disk and turns indices read-only at 95%, and two corpora plus a backup plus a
+staged snapshot will get there faster than expected.

--- a/deploy/litellm/demo-config.yaml
+++ b/deploy/litellm/demo-config.yaml
@@ -24,6 +24,15 @@ model_list:
   - model_name: os.environ/KI_EMBEDDING_MODEL
     litellm_params:
       model: os.environ/KI_EMBEDDING_UPSTREAM
+      # Pin the width of a query vector to the width of the index, because the
+      # two are only equal by luck. text-embedding-3-small is natively 1536, so
+      # this is a no-op for it; gemini-embedding-2 is natively 3072 and LiteLLM
+      # maps `dimensions` onto Gemini's output_dimensionality (MRL truncation)
+      # to bring it back to 1536. Without the line, swapping the corpus to a
+      # Gemini-embedded one gets every query embed rejected with "returned 3072
+      # dimensions; index expects 1536" — and the index name will not warn you,
+      # since it is derived from the dimension the index was built at.
+      dimensions: 1536
       api_key: os.environ/KI_EMBEDDING_API_KEY
       input_cost_per_token: os.environ/KI_EMBEDDING_INPUT_COST_PER_TOKEN
       output_cost_per_token: 0.0

--- a/deploy/reindex_from_embeddings.py
+++ b/deploy/reindex_from_embeddings.py
@@ -25,6 +25,12 @@ one process per core, each taking a disjoint shard of the ranges:
       KI_REINDEX_SHARDS=6 KI_REINDEX_SHARD=$i python reindex_from_embeddings.py &
     done
 
+Size that to the cluster, not just to the cores. Measured 2026-08-07 against a
+single node with a 4 GB heap: 6 shards x 8 threads (48 concurrent bulks of ~3 MB)
+drove OpenSearch into indexing-pressure backpressure and managed 131 chunks/s,
+while 2 x 4 with KI_REINDEX_BATCH=200 sustained ~1,000 chunks/s with no
+rejections at all. More writers past that point is slower, not faster.
+
 Run it inside the appliance container, which already has the config and the
 models:
 
@@ -114,14 +120,27 @@ def _worker(slice_no: int, bounds: tuple[str, str | None], dsn: str, total: int,
             rows = list(session.scalars(stmt.order_by(Chunk.id).limit(BATCH)))
             if not rows:
                 break
-            try:
-                index.bulk_sync([], rows)
-                n = len(rows)
-            except Exception as exc:  # noqa: BLE001 - report, do not abort the run
-                n = 0
-                with _lock:
-                    _failed += len(rows)
-                sys.stdout.write(f"\n  slice {slice_no}: {type(exc).__name__}: {exc}\n")
+            # A 429 from OpenSearch is backpressure, not failure: the cluster is
+            # telling us to slow down, and the original code recorded that as a
+            # permanently lost batch. Retrying with a backoff makes the run
+            # self-throttling instead of silently dropping chunks.
+            n = 0
+            for _attempt in range(10):
+                try:
+                    index.bulk_sync([], rows)
+                    n = len(rows)
+                    break
+                except Exception as exc:  # noqa: BLE001 - report, do not abort the run
+                    text = str(exc)
+                    transient = any(s in text for s in
+                                    ("429", "503", "circuit_breaking", "Timeout", "timed out"))
+                    if transient and _attempt < 9:
+                        time.sleep(min(1.5 ** _attempt, 20.0))
+                        continue
+                    with _lock:
+                        _failed += len(rows)
+                    sys.stdout.write(f"\n  slice {slice_no}: {type(exc).__name__}: {exc}\n")
+                    break
             indexed += n
             with _lock:
                 _done += n


### PR DESCRIPTION
Found while migrating the hosted demo from the 13.5k corpus to a 51,683-document one (4,347,719 chunks). Both code changes are bugs that fail quietly — nothing crashes, nothing logs an error, and the result looks fine until someone runs a search.

## `reindex_from_embeddings.py` — retry backpressure instead of dropping the batch

A 429 from OpenSearch means "slow down". The script treated it as a permanent failure: count the batch, move on, never retry. Since the run still exits with a `failed=` tally rather than crashing, the outcome is an index quietly short of the corpus behind it.

Rebuilding 4.35M chunks hit this hard. Six shards × eight threads put 48 concurrent multi-megabyte bulk requests against a 4 GB heap; the node pushed back and **~125,000 chunks were lost in the first ten minutes**, with throughput at 131 chunks/s. Retrying transient errors with a backoff makes the run self-throttling — the same corpus then indexed at **~1,000 chunks/s with zero failures**.

The docstring's worked example is unchanged, but now says to size the fan-out to the cluster rather than the core count, with both measurements — following it verbatim on a small host is what produced the loss.

## `demo-config.yaml` — pin the query vector to the index width

The embedding block passed no `dimensions`, which worked only because `text-embedding-3-small` is natively 1536, the same width the index is built at. That equality is luck, not design.

It stops holding the moment a deployment points at a model with a different native width: `gemini-embedding-2` returns **3072**, so every query embed comes back too wide and is rejected against a 1536-dim index. LiteLLM maps `dimensions` onto the provider's own parameter (Gemini's `output_dimensionality`, which is MRL truncation). It's a no-op for a model already at 1536, so the line stays correct across a provider change rather than needing to be remembered during one.

## `README-hosted-demo.md` — what loading a corpus actually involves

"Loading the index" was four lines and assumed the happy path.

The section worth reviewing is the embedding check. **The index name is derived from the embedding signature, and that signature keys on vector width, not on which model produced the vectors.** Two different models at the same width resolve to the same index name — so loading a corpus embedded by one model into a deployment that embeds queries with another succeeds at every step, healthchecks included, while dense retrieval compares vectors from two different spaces and returns confident nonsense. The name cannot warn you; only comparing the envs can, and the width has to be checked separately from the model because there is no environment variable carrying it.

Also covers the two-store problem (a dump carries Postgres but not the search index), snapshot-restore vs. rebuild and what each costs, backing up before replacing a live corpus, restoring into a side database so the outage is the index step alone, and the alias approach that would remove even that.

## Not in this PR

The scripts that performed the migration are wired to one specific deployment — compose project, container and volume names, paths, transfer bucket — so they live in the internal infra repo instead. This repo is AGPL and public, and its hosted-demo doc already writes `PROJECT=…` in place of the real one; that convention seemed worth keeping. Only the deployment-agnostic knowledge is here.

## Validation

Both fixes are running in production on the hosted demo. The swap completed with 13m12s of downtime; post-swap the index holds 4,347,901 documents against 4,347,719 chunks, and query embedding returns `gemini-embedding-2` at 1536 dims — matching the corpus, which is what the `dimensions` change buys.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186X5GzsEPj553eADtNCRHK)_