### PR TITLE
entities: resolve a mention to one firm-wide entity, at insertion

### DIFF
--- a/docs/src/content/docs/concepts/data-model.md
+++ b/docs/src/content/docs/concepts/data-model.md
@@ -93,6 +93,8 @@ table maintained by the connector.
 |---|---|
 | `id` | uuid |
 | `name`, `aliases[]` | all name forms seen for one client entity |
+| `normalized_name`, `normalized_aliases[]` | the same forms under one comparison rule (`knowledge_index.entity_names`): case-folded, transliterated, punctuation- and legal-form-stripped. This is the key insertion resolves on, so one real client is one row across every matter |
+| `identity_discriminator` | empty unless a mention carried a register identifier contradicting the same-named incumbent, in which case it holds that identifier. `(normalized_name, identity_discriminator)` is unique, so two companies that genuinely share a name each get a row and nothing else can |
 | `kind` | `legal_entity \| natural_person` |
 | `identifiers` | company-register number, tax id, DMS client code, whatever the firm has |
 | provenance | confidence + evidence (clients are usually *imported* from the practice-management system and are then authoritative, `confidence = 1.0`) |
@@ -117,7 +119,9 @@ retrieval is matter-aware.
 
 ### Party (natural or legal person)
 Shared by matters (an opposing party in one matter may be the client in another;
-conflict checks care about exactly this). `{id, name, aliases, kind, identifiers}`.
+conflict checks care about exactly this). Same identity columns as Client:
+`{id, name, aliases, normalized_name, normalized_aliases, identity_discriminator,
+kind, identifiers}`.
 
 ### Document (logical) and DocumentVersion
 A **Document** is the logical work product ("the SPA for project Falke"); a

--- a/docs/src/content/docs/product/pipeline.md
+++ b/docs/src/content/docs/product/pipeline.md
@@ -95,6 +95,22 @@ hash and one `Extraction` provenance row per document. An untyped result is reco
 honestly (`doc_type = NULL`) with the fingerprint of the scope that judged it, so a
 later, richer ontology re-types exactly those documents.
 
+Parties are searched by the agent (`search_entities`) but resolved by rule, so one
+real company is one row across every matter it appears on. A mention links to an
+entity the firm already holds when the two share a typed identifier, when their
+normalized names are identical or the mention's name is already on that entity's
+alias ledger, or when one name contains the other token-for-token *and* something
+beyond the name agrees — the entity is already on this matter, shares a matter with
+another party named on this document, or acts on another matter for this matter's
+client. Anything weaker is left to the agent, and a new entity created next to a
+known same-name candidate records that candidate on its own `provenance.resolution`,
+so it stays countable. Two companies that genuinely share a name are kept apart by a
+contradicting register identifier, which is the only thing the uniqueness constraint
+on the identity key admits as a second row. `role = client` means the party the firm
+acts for: the firm itself is recorded as `advisor` when [`firm.name`](#configuration)
+is set, an entity already carrying a role on the matter keeps it, and on an imported
+matter the practice-management client outranks any document-level claim.
+
 ### Extract decisions (`extract_decisions`)
 
 Reads the `structured_json` artifact's `revisions` and `comments`. With no revision
@@ -251,13 +267,15 @@ unfinished sync run: a stranded run would otherwise stop indexing silently.
 
 ## Configuration
 
-All fields live under `pipeline.*` in the saved configuration; scalar fields can be
-pinned by environment variables using the `KI_` prefix and `__` as the nesting
-delimiter (an environment-pinned setting refuses console edits with a 409 rather than
-silently losing them).
+All fields live under `pipeline.*` in the saved configuration, except `firm.*` as
+noted; scalar fields can be pinned by environment variables using the `KI_` prefix and
+`__` as the nesting delimiter (an environment-pinned setting refuses console edits with
+a 409 rather than silently losing them).
 
 | Field | Env var | Default | Effect |
 | --- | --- | --- | --- |
+| `firm.name` | `KI_FIRM__NAME` | `""` | Whose appliance this is — the one fact no document states. The firm is on its own letterhead, signs its own engagement letters and is copied on every mail, so extraction reads it as a party; naming it here records it as `advisor` instead of as the firm's own client. Empty and inert by default: an appliance that has not been told whose it is must not guess, and a wrong name here would demote a real client. |
+| `firm.aliases` | `KI_FIRM__ALIASES` | `[]` | The other forms the firm writes itself in — the short letterhead name, the historical partnership name, the English rendering. Compared the same way entity names are, so legal forms and punctuation need not be repeated. |
 | `pipeline.max_file_mb` | `KI_PIPELINE__MAX_FILE_MB` | 512 | Fetch limit; a larger blob raises `ArtifactTooLarge` and quarantines deterministically. |
 | `pipeline.claim_timeout_seconds` | `KI_PIPELINE__CLAIM_TIMEOUT_SECONDS` | 900 | A `running` claim older than this is failed as `StaleClaim` and retried. |
 | `pipeline.retry_base_seconds` | `KI_PIPELINE__RETRY_BASE_SECONDS` | 5 | Base of the exponential backoff (`base × 2^(attempts−1)`). |

--- a/migrations/versions/d9a41f6c73b2_entity_identity_keys.py
+++ b/migrations/versions/d9a41f6c73b2_entity_identity_keys.py
@@ -1,0 +1,111 @@
+"""give clients and parties an identity key, and make a twin impossible
+
+Insertion created a new entity nearly every time it met one: on a 9,288-document
+run whose ground truth is 46 clients, the clients table held 1,212 rows, 1,076 of
+them touching exactly one matter. 973 of those creations reused a normalized name
+the estate already held, and 293 of THOSE happened within 60 seconds of the
+previous one — a plain race between documents extracting in parallel, with nothing
+in the schema able to refuse it.
+
+This adds the key the resolver matches on and the constraint that makes the race
+unwinnable:
+
+* normalized_name — case-folded, transliterated, diacritic-folded,
+  punctuation-stripped, legal-form-stripped (knowledge_index.entity_names). Written
+  by the application rather than by a generated column, deliberately: the rule has
+  to be byte-identical in the resolver and in the constraint, and a plpgsql copy of
+  it is how the two drift apart.
+* identity_discriminator — empty for every entity the estate has no reason to split.
+  Two genuinely different companies do share a name; when a mention carries a
+  register identifier that contradicts the same-named incumbent, the new row records
+  it here and the unique index admits the second entity. Nothing else gets past.
+* normalized_aliases — every other name form seen for the entity, so a variant the
+  corpus has already taught the resolver matches exactly next time.
+
+The backfill computes normalized_name in SQL for existing rows. It is an
+APPROXIMATION of the Python rule (it has no legal-form list), which is fine for one
+purpose only: giving every existing row a non-empty key so the unique index can be
+built. Rows this repair leaves merged or split wrongly are the data repair's
+problem, not the schema's — and a fresh estate never runs it.
+
+The unique index is created on the deduplicated key. If existing data already holds
+duplicates the index build fails loudly rather than picking a winner: choosing which
+of two entities survives is a merge, and a migration must never perform one.
+
+Revision ID: d9a41f6c73b2
+Revises: c4e18b9d2f07
+Create Date: 2026-08-08
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d9a41f6c73b2"
+down_revision: Union[str, Sequence[str], None] = "c4e18b9d2f07"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLES = ("clients", "parties")
+
+
+def upgrade() -> None:
+    # similarity() and the trigram GIN operator class the resolver's name search
+    # rides on. IF NOT EXISTS so a deployment that already has it is untouched.
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+    for table in TABLES:
+        op.add_column(table, sa.Column("normalized_name", sa.Text(), nullable=True))
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_discriminator", sa.Text(), nullable=False, server_default=""
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "normalized_aliases",
+                sa.dialects.postgresql.JSONB(),
+                nullable=False,
+                server_default="[]",
+            ),
+        )
+        # unaccent is not IMMUTABLE, so it cannot appear in an index expression —
+        # here it only writes a column value, which is fine.
+        op.execute(
+            f"""
+            UPDATE {table}
+               SET normalized_name = trim(regexp_replace(
+                     lower(unaccent(translate(name, '&', ' '))),
+                     '[^a-z0-9]+', ' ', 'g'))
+            """
+        )
+        op.alter_column(table, "normalized_name", nullable=False)
+        op.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS ix_{table}_normalized_name_trgm
+            ON {table} USING gin (normalized_name gin_trgm_ops)
+            """
+        )
+        op.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS ix_{table}_normalized_aliases
+            ON {table} USING gin (normalized_aliases jsonb_path_ops)
+            """
+        )
+        op.create_unique_constraint(
+            f"uq_{table}_identity", table, ["normalized_name", "identity_discriminator"]
+        )
+
+
+def downgrade() -> None:
+    for table in TABLES:
+        op.drop_constraint(f"uq_{table}_identity", table, type_="unique")
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_normalized_aliases")
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_normalized_name_trgm")
+        op.drop_column(table, "normalized_aliases")
+        op.drop_column(table, "identity_discriminator")
+        op.drop_column(table, "normalized_name")

--- a/migrations/versions/d9a41f6c73b2_entity_identity_keys.py
+++ b/migrations/versions/d9a41f6c73b2_entity_identity_keys.py
@@ -22,15 +22,21 @@ unwinnable:
 * normalized_aliases — every other name form seen for the entity, so a variant the
   corpus has already taught the resolver matches exactly next time.
 
-The backfill computes normalized_name in SQL for existing rows. It is an
-APPROXIMATION of the Python rule (it has no legal-form list), which is fine for one
-purpose only: giving every existing row a non-empty key so the unique index can be
-built. Rows this repair leaves merged or split wrongly are the data repair's
-problem, not the schema's — and a fresh estate never runs it.
+The backfill runs the Python rule itself over the existing rows rather than an
+equivalent written in SQL. A SQL rendering is easy to write and wrong in exactly the
+way this module warns about: measured against the rule on five ordinary names,
+`lower(unaccent(...))` produced "whitfield crane llp", "nordwind energie gmbh" and
+"muller verwaltungs ag" where the application produces "whitfield crane", "nordwind
+energie" and "mueller verwaltungs" — five keys out of five that the resolver would
+never compute again. Every one of those rows would be invisible to the search that
+is supposed to find it, and the next document naming the company would create the
+twin this change exists to prevent.
 
 The unique index is created on the deduplicated key. If existing data already holds
-duplicates the index build fails loudly rather than picking a winner: choosing which
-of two entities survives is a merge, and a migration must never perform one.
+duplicates the migration stops and names them rather than picking a winner: choosing
+which of two entities survives is a merge, and a migration must never perform one.
+Repair the duplicates first (the estate this was measured on was repaired by a
+separate maintenance pass), then migrate.
 
 Revision ID: d9a41f6c73b2
 Revises: c4e18b9d2f07
@@ -41,6 +47,9 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from knowledge_index.entity_names import normalize_entity_name
 
 # revision identifiers, used by Alembic.
 revision: str = "d9a41f6c73b2"
@@ -50,12 +59,70 @@ depends_on: Union[str, Sequence[str], None] = None
 
 TABLES = ("clients", "parties")
 
+# Rows per round trip. Large enough that a full estate is a handful of statements,
+# small enough that the parameter list stays inside what the driver will bind.
+_BACKFILL_BATCH = 500
+
+
+def _backfill(connection, table: str) -> None:
+    """Give every existing row the key the application would compute for it."""
+    rows = connection.execute(sa.text(f"SELECT id, name FROM {table} ORDER BY id")).all()
+    updates = [
+        {"row_id": row_id, "normalized": normalize_entity_name(name)} for row_id, name in rows
+    ]
+    statement = sa.text(f"UPDATE {table} SET normalized_name = :normalized WHERE id = :row_id")
+    for start in range(0, len(updates), _BACKFILL_BATCH):
+        connection.execute(statement, updates[start : start + _BACKFILL_BATCH])
+
+
+def _refuse_existing_duplicates(connection, table: str) -> None:
+    """Stop before the index build, naming what has to be merged first.
+
+    Postgres would refuse the index on its own, but it names one colliding value and
+    calls it "could not create unique index" — which reads as a broken migration
+    rather than as an estate holding two rows for one company. The names are the
+    actionable part, so they are what this reports.
+    """
+    duplicates = connection.execute(
+        sa.text(
+            f"""
+            SELECT normalized_name, count(*) AS rows
+              FROM {table}
+             GROUP BY normalized_name, identity_discriminator
+            HAVING count(*) > 1
+             ORDER BY rows DESC, normalized_name
+             LIMIT 20
+            """
+        )
+    ).all()
+    if not duplicates:
+        return
+    total = connection.execute(
+        sa.text(
+            f"""
+            SELECT count(*) FROM (
+                SELECT 1 FROM {table}
+                 GROUP BY normalized_name, identity_discriminator
+                HAVING count(*) > 1
+            ) AS collisions
+            """
+        )
+    ).scalar()
+    listed = ", ".join(f"{name!r} ({rows} rows)" for name, rows in duplicates)
+    raise RuntimeError(
+        f"{table} already holds {total} name(s) with more than one row, so the identity "
+        f"constraint cannot be created: {listed}"
+        + (" …" if total > len(duplicates) else "")
+        + ". Merge them first — deciding which row survives is a data repair and a "
+        "migration must never make that choice for you."
+    )
+
 
 def upgrade() -> None:
     # similarity() and the trigram GIN operator class the resolver's name search
     # rides on. IF NOT EXISTS so a deployment that already has it is untouched.
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-    op.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+    connection = op.get_bind()
     for table in TABLES:
         op.add_column(table, sa.Column("normalized_name", sa.Text(), nullable=True))
         op.add_column(
@@ -68,22 +135,14 @@ def upgrade() -> None:
             table,
             sa.Column(
                 "normalized_aliases",
-                sa.dialects.postgresql.JSONB(),
+                postgresql.JSONB(),
                 nullable=False,
                 server_default="[]",
             ),
         )
-        # unaccent is not IMMUTABLE, so it cannot appear in an index expression —
-        # here it only writes a column value, which is fine.
-        op.execute(
-            f"""
-            UPDATE {table}
-               SET normalized_name = trim(regexp_replace(
-                     lower(unaccent(translate(name, '&', ' '))),
-                     '[^a-z0-9]+', ' ', 'g'))
-            """
-        )
+        _backfill(connection, table)
         op.alter_column(table, "normalized_name", nullable=False)
+        _refuse_existing_duplicates(connection, table)
         op.execute(
             f"""
             CREATE INDEX IF NOT EXISTS ix_{table}_normalized_name_trgm

--- a/src/knowledge_index/config.py
+++ b/src/knowledge_index/config.py
@@ -227,6 +227,36 @@ class RetrievalConfig(BaseModel):
     clause_embeddings: bool = True
 
 
+class FirmConfig(BaseModel):
+    """Whose appliance this is — the one fact the entity layer cannot infer.
+
+    The firm appears on its own documents constantly: it signs the engagement letter,
+    it is on the letterhead, it is copied on every mail. Extraction read that as a
+    party and, 16 times on the 9,288-document run, filed the firm itself as a client
+    of the firm. There is no signal in a document that says "this one is us", so the
+    deployment says it once here and the insertion pipeline enforces it structurally
+    (pipeline.runner._effective_party_role) instead of asking a model not to.
+
+    Empty by default and inert when empty: an appliance nobody has told whose it is
+    must not guess, and a wrong name here would silently demote a real client.
+    ``aliases`` carries the other forms a firm writes itself in — the short name on
+    the letterhead, the historical partnership name, the English rendering.
+    """
+
+    name: str = ""
+    aliases: list[str] = Field(default_factory=list)
+
+    def is_self(self, candidate: str | None) -> bool:
+        """Whether a name on a document is this firm, compared the way entities are."""
+        from knowledge_index.entity_names import normalize_entity_name
+
+        normalized = normalize_entity_name(candidate)
+        if not normalized:
+            return False
+        known = {normalize_entity_name(form) for form in [self.name, *self.aliases]}
+        return normalized in known - {""}
+
+
 class EnvironmentConfig(BaseModel):
     """Caps that keep the RL-environment builder sparse and firm-specific."""
 
@@ -684,6 +714,7 @@ class AppConfig(BaseSettings):
     artifact_dir: Path = Path(".ki/artifacts")
     # The gateway model the reference /api/ask assistant plans and answers with.
     ask_model: str = Field(default_factory=_default_llm)
+    firm: FirmConfig = Field(default_factory=FirmConfig)
     pipeline: PipelineConfig = Field(default_factory=PipelineConfig)
     retrieval: RetrievalConfig = Field(default_factory=RetrievalConfig)
     environments: EnvironmentConfig = Field(default_factory=EnvironmentConfig)

--- a/src/knowledge_index/db/models.py
+++ b/src/knowledge_index/db/models.py
@@ -33,7 +33,15 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    relationship,
+    validates,
+)
+
+from knowledge_index.entity_names import normalize_entity_name
 
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
 
@@ -311,28 +319,97 @@ class Artifact(Base):
 # ------------------------------------------------------------------------ knowledge layer
 
 
-class Client(TimestampMixin, Base):
-    __tablename__ = "clients"
+def _normalized_name_default(context) -> str:
+    """``normalized_name`` derived from whatever ``name`` this statement writes.
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    Set as a column default rather than left to the caller so no insert path can
+    produce a row the uniqueness constraint and the resolver disagree about — the
+    constraint is only worth its name if every row is keyed the same way.
+    """
+    parameters = context.get_current_parameters()
+    return normalize_entity_name(parameters.get("name"))
+
+
+class EntityIdentityMixin:
+    """The columns that make one real-world entity one row.
+
+    ``normalized_name`` is the identity key (see knowledge_index.entity_names) and
+    carries a trigram index, so the insertion-time resolver can ask "who does the
+    estate already know by roughly this name" instead of the substring test it used
+    to run — which found "Verimark Hospitality Group Inc." from "Verimark
+    Hospitality Group Inc" and from nothing else.
+
+    ``identity_discriminator`` is empty for every entity the estate has no reason to
+    split. Two genuinely different companies DO share a name, and the corpus plants
+    exactly that case; when a mention carries a register identifier that contradicts
+    the same-named incumbent's, the new row records that identifier here and the
+    unique constraint admits it as a second, deliberately distinct entity. Anything
+    else that shares a normalized name is the same entity — 46 clients spread over
+    266 matters is what a law firm looks like, and 1,076 single-matter clients out
+    of 1,212 was the inverse of it.
+
+    ``normalized_aliases`` is every OTHER name form seen for this entity, normalized,
+    so a variant the corpus has already taught the resolver resolves exactly rather
+    than fuzzily on the next document that uses it.
+    """
+
     name: Mapped[str] = mapped_column(Text)
+    normalized_name: Mapped[str] = mapped_column(Text, default=_normalized_name_default)
+    identity_discriminator: Mapped[str] = mapped_column(Text, default="", server_default="")
     aliases: Mapped[list] = mapped_column(JSONVariant, default=list)
+    normalized_aliases: Mapped[list] = mapped_column(JSONVariant, default=list)
     kind: Mapped[str] = mapped_column(String(20), default="legal_entity")
     identifiers: Mapped[dict] = mapped_column(JSONVariant, default=dict)  # HRB, USt-Id, DMS code
     provenance: Mapped[dict | None] = mapped_column(JSONVariant)
 
+    @validates("name")
+    def _keep_normalized_name(self, _key: str, value: str) -> str:
+        """Renaming an entity re-keys it, in the same statement.
 
-class Party(TimestampMixin, Base):
+        The column default covers Core inserts; this covers every ORM write,
+        including the ones that only touch ``name``. A row whose normalized name no
+        longer matches its name is invisible to the resolver that is supposed to
+        find it, which is the failure this whole change exists to end.
+        """
+        self.normalized_name = normalize_entity_name(value)
+        return value
+
+
+def _entity_identity_args(table: str) -> tuple:
+    """Uniqueness and the two lookup indexes, identical for clients and parties."""
+    return (
+        UniqueConstraint(
+            "normalized_name", "identity_discriminator", name=f"uq_{table}_identity"
+        ),
+        Index(
+            f"ix_{table}_normalized_name_trgm",
+            "normalized_name",
+            postgresql_using="gin",
+            postgresql_ops={"normalized_name": "gin_trgm_ops"},
+        ),
+        Index(
+            f"ix_{table}_normalized_aliases",
+            "normalized_aliases",
+            postgresql_using="gin",
+            postgresql_ops={"normalized_aliases": "jsonb_path_ops"},
+        ),
+    )
+
+
+class Client(EntityIdentityMixin, TimestampMixin, Base):
+    __tablename__ = "clients"
+    __table_args__ = _entity_identity_args("clients")
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+
+
+class Party(EntityIdentityMixin, TimestampMixin, Base):
     """Any natural/legal person appearing in matters or documents (incl. non-clients)."""
 
     __tablename__ = "parties"
+    __table_args__ = _entity_identity_args("parties")
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
-    name: Mapped[str] = mapped_column(Text)
-    aliases: Mapped[list] = mapped_column(JSONVariant, default=list)
-    kind: Mapped[str] = mapped_column(String(20), default="legal_entity")
-    identifiers: Mapped[dict] = mapped_column(JSONVariant, default=dict)
-    provenance: Mapped[dict | None] = mapped_column(JSONVariant)
 
 
 class Matter(TimestampMixin, Base):

--- a/src/knowledge_index/entity_names.py
+++ b/src/knowledge_index/entity_names.py
@@ -74,6 +74,14 @@ def normalize_entity_name(name: str | None) -> str:
 
     Token order is preserved so the value stays readable in the database and in a
     tool result; order-insensitivity is the comparison's job, not the string's.
+
+    Stripping only happens when something survives it. A mention the extraction agent
+    left as a bare form — "GmbH & Co. KG", "The Company", "S.A." — has every one of
+    its tokens on the two lists above, and returning "" for it would key EVERY such
+    mention to the same value. Under the uniqueness constraint that is not a missing
+    match, it is a silent merge: the second unrelated company written that way becomes
+    the first one. The legal form is noise around an identity, not when it is all the
+    identity there is.
     """
     text = (name or "").strip().lower()
     if not text:
@@ -85,12 +93,13 @@ def normalize_entity_name(name: str | None) -> str:
     text = "".join(char for char in text if not unicodedata.combining(char))
     text = _JOINING_PUNCTUATION.sub("", text)
     text = _PUNCTUATION.sub(" ", text)
+    all_tokens = text.split()
     tokens = [
         token
-        for token in text.split()
+        for token in all_tokens
         if token not in LEGAL_FORM_TOKENS and token not in CONNECTOR_TOKENS
     ]
-    return " ".join(tokens)
+    return " ".join(tokens or all_tokens)
 
 
 def name_tokens(normalized: str) -> frozenset[str]:

--- a/src/knowledge_index/entity_names.py
+++ b/src/knowledge_index/entity_names.py
@@ -1,0 +1,148 @@
+"""One normalization rule for legal-entity names, and the comparison built on it.
+
+Dependency-light on purpose: the persistence layer writes ``normalized_name`` with
+it, the insertion-time resolver searches on it, and the uniqueness constraint is
+defined over the column it produces. If the rule lived in two places — say Python
+for the search and plpgsql for a generated column — the two would drift and the
+constraint would stop meaning what the resolver believes it means.
+
+Why normalization alone is not the answer, and what is. On the 9,288-document run
+that motivated this module, 985 distinct client names normalized down to 942: the
+duplicate rows were not spelling variants of each other, they were the SAME name
+searched with a substring predicate that could not match it ("Nexford" against a
+stored "Nexford Industrial Holdings Inc."). So the comparison here is token-set
+based rather than string-containment based, and normalization only removes the
+noise that is genuinely noise — case, punctuation, diacritics, the legal form.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from difflib import SequenceMatcher
+
+# Legal-form tokens. Dropped wherever they appear, not only at the end: a name is
+# routinely written "Nexford Industrial Holdings Inc." in one document and
+# "Nexford Industrial Holdings" in the next, and German filings put the form in
+# the middle ("Nexford GmbH & Co. KG Beteiligungen").
+#
+# "Holdings", "Group" and "Partners" are deliberately NOT here: they are part of a
+# company's identity, and dropping them would merge "Verimark Group" into
+# "Verimark Hospitality" rather than merely letting the two find each other.
+# Two- and three-letter forms that are also ordinary words ("as", "ad", "lc") are
+# left out on purpose: dropping them costs more than it saves when they are the
+# only distinctive token a name has.
+LEGAL_FORM_TOKENS = frozenset(
+    """
+    ag gmbh mbh ug kg kgaa ohg gbr eg ev se sa sas sarl sca scs spa srl sl slu
+    nv bv cv ab asa aps oy oyj plc llp lllp llc lp pc pllc ltd limited inc
+    incorporated corp corporation co company pte pty zoo doo jsc pjsc ojsc oao zao
+    """.split()
+)
+
+# Words that carry no identity of their own once the legal form is gone. "&" and
+# "and" are the same conjunction written two ways ("Whitfield & Crane" /
+# "Whitfield and Crane"), and the articles are noise in every language the corpus
+# mixes.
+CONNECTOR_TOKENS = frozenset("and und et the der die das le la les el los".split())
+
+# German umlauts and eszett have two accepted spellings and legal documents use
+# both. Folding to the diacritic-free form alone would map "Müller" to "muller"
+# and leave "Mueller" unmatched, so the transliteration runs first.
+_TRANSLITERATIONS = {
+    "ä": "ae",
+    "ö": "oe",
+    "ü": "ue",
+    "ß": "ss",
+    "æ": "ae",
+    "ø": "oe",
+    "å": "aa",
+    "đ": "d",
+    "ł": "l",
+}
+
+# Removed outright rather than turned into a space, because these join a word
+# rather than separate two: "L.P." has to become one "lp" token the legal-form list
+# recognizes, not "l" and "p", and "Sainsbury's" must not shed an "s".
+_JOINING_PUNCTUATION = re.compile(r"[.'’´`]")
+_PUNCTUATION = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def normalize_entity_name(name: str | None) -> str:
+    """The comparable form of an entity name: case-folded, transliterated,
+    diacritic-folded, punctuation-stripped, legal form and conjunctions removed.
+
+    Token order is preserved so the value stays readable in the database and in a
+    tool result; order-insensitivity is the comparison's job, not the string's.
+    """
+    text = (name or "").strip().lower()
+    if not text:
+        return ""
+    text = text.replace("&", " and ")
+    for source, replacement in _TRANSLITERATIONS.items():
+        text = text.replace(source, replacement)
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    text = _JOINING_PUNCTUATION.sub("", text)
+    text = _PUNCTUATION.sub(" ", text)
+    tokens = [
+        token
+        for token in text.split()
+        if token not in LEGAL_FORM_TOKENS and token not in CONNECTOR_TOKENS
+    ]
+    return " ".join(tokens)
+
+
+def name_tokens(normalized: str) -> frozenset[str]:
+    """The token set a normalized name is compared as."""
+    return frozenset(normalized.split())
+
+
+def name_similarity(left: str, right: str) -> tuple[float, str]:
+    """How alike two ALREADY-NORMALIZED names are, and which rule said so.
+
+    Returns ``(score, component)`` with score in 0..1. The components, strongest
+    first:
+
+    ``exact``
+        identical normalized names.
+    ``token_containment``
+        every token of the shorter name appears in the longer one — the case the
+        old substring predicate could only match in one direction. "Verimark
+        Group" and "Verimark Hospitality Group Inc." reach each other here, and
+        so do "Nexford" and "Nexford Industrial Holdings Inc.". A single shared
+        token scores lower than three, because a one-word containment ("Meridian"
+        inside "Meridian Health Partners") is a much weaker claim.
+    ``token_overlap``
+        partial overlap, scored by how much of the shorter name is covered and
+        how much of the union the two share.
+    ``characters``
+        no useful token overlap, but the strings themselves are near-identical —
+        typos and transcription slips ("Verimarc" for "Verimark").
+    """
+    if not left or not right:
+        return 0.0, ""
+    if left == right:
+        return 1.0, "exact"
+    left_tokens, right_tokens = name_tokens(left), name_tokens(right)
+    shorter, longer = (
+        (left_tokens, right_tokens)
+        if len(left_tokens) <= len(right_tokens)
+        else (right_tokens, left_tokens)
+    )
+    shared = shorter & longer
+    union = left_tokens | right_tokens
+    coverage = len(shared) / len(shorter) if shorter else 0.0
+    jaccard = len(shared) / len(union) if union else 0.0
+    if shared and coverage == 1.0:
+        # 0.80 at one shared token, 0.90 at three, plus how much of the whole
+        # union the two names agree on.
+        score = 0.80 + 0.05 * min(2, len(shorter) - 1) + 0.05 * jaccard
+        return round(score, 4), "token_containment"
+    characters = SequenceMatcher(None, left, right).ratio()
+    if shared:
+        score = max(0.45 * coverage + 0.35 * jaccard, 0.85 * characters)
+        return round(score, 4), "token_overlap" if score > 0.85 * characters else "characters"
+    if characters >= 0.85:
+        return round(0.85 * characters, 4), "characters"
+    return 0.0, ""

--- a/src/knowledge_index/pipeline/extraction.py
+++ b/src/knowledge_index/pipeline/extraction.py
@@ -86,11 +86,14 @@ class TypedIdentifier(BaseModel):
 
 
 class ExtractedParty(BaseModel):
-    """One party named on the document, resolved to a firm-wide entity by the agent.
+    """One party named on the document.
 
-    The agent decides link-vs-create with the search_entities tool: it searches the
-    firm's known parties/clients and, only when a candidate is genuinely the SAME
-    real-world entity, reuses its id — a matching name alone is never enough.
+    The agent searches with search_entities and links what it recognizes, but it does
+    not have the last word: whether two names are one entity is decided by rule in
+    pipeline.runner._resolve_document_parties, which links on a shared identifier, on
+    an identical normalized name, or on a strong name match with corroboration. What
+    the agent contributes that no rule can is the identifiers printed on the page and
+    an honest role.
     """
 
     name: str = Field(
@@ -98,13 +101,19 @@ class ExtractedParty(BaseModel):
         "number, or defined-term label. Register numbers/LEI belong in identifiers. Write the "
         "same entity identically everywhere so mentions across documents match."
     )
-    role: PartyRole = Field(description="This party's role on THIS document.")
+    role: PartyRole = Field(
+        description="This party's role on THIS document. 'client' means the party THIS "
+        "FIRM acts for on this matter — not merely a prominent company on the page, and "
+        "never this firm itself. A counterparty, a co-investor, a guarantor, a person "
+        "signing for a company, an adviser, a court: all of these have their own role."
+    )
     existing_id: str | None = Field(
         default=None,
         description="The id of an existing entity returned by search_entities, when this "
-        "party IS that already-known entity. null to create a new one. Reuse an id ONLY "
-        "when identifiers or the matter context confirm it — never on name similarity alone. "
-        "null is only accepted for a party you actually searched with search_entities.",
+        "party IS that already-known entity. A candidate whose match.verdict is "
+        "same_entity IS this party — copy its id. null when the search genuinely found "
+        "nothing that is this entity; null is only accepted for a party you actually "
+        "searched with search_entities.",
     )
     kind: str = Field(
         default="legal_entity",
@@ -112,7 +121,9 @@ class ExtractedParty(BaseModel):
     )
     identifiers: list[TypedIdentifier] = Field(
         default_factory=list,
-        description="Register numbers/LEI/tax ids printed for THIS party, if any.",
+        description="Register numbers/LEI/tax ids printed for THIS party, if any. These "
+        "are what proves identity — copy every one the document shows, and they also "
+        "keep two same-named but genuinely different companies apart.",
     )
 
 
@@ -495,15 +506,29 @@ METADATA_SYSTEM = (
     "Party resolution — for every party named on the face of the document (the client "
     "the firm acts for, the contracting parties and counterparties, guarantors and "
     "agents, the court or authority, notaries, and any advising law firms):\n"
-    "(a) Give its role on THIS document, and its CANONICAL legal name only — strip the "
-    "address/seat, register text, and defined-term labels so the same entity reads "
-    "identically everywhere.\n"
-    "(b) Call search_entities for EVERY party — with its name (and any register "
-    "number/LEI) — BEFORE deciding whether it is new. If a returned candidate is the "
-    "SAME real-world entity, put its id in existing_id; a matching NAME ALONE is never "
-    "enough — different companies share names, so reuse an id only when identifiers or "
-    "the matter context agree. Otherwise leave existing_id null to create a new entity.\n"
-    "(c) Any non-null existing_id MUST be an id returned by search_entities in this "
+    "(a) Give its CANONICAL legal name only — strip the address/seat, register text, "
+    "and defined-term labels so the same entity reads identically everywhere — and copy "
+    "every register number, LEI or tax id the document prints for it into identifiers. "
+    "Those identifiers are what proves two mentions are one company, and what keeps two "
+    "same-named companies apart.\n"
+    "(b) Give its role on THIS document. 'client' is the party THIS FIRM acts for on "
+    "this matter. There is normally exactly one, it is the same party on every document "
+    "of the matter, and it is NEVER this firm: a counterparty, a co-investor, a "
+    "guarantor, a person signing on behalf of a company, an adviser, a notary or a court "
+    "each take their own role, not 'client'. When you cannot tell whose side the firm is "
+    "on from this document alone, use the role you CAN justify rather than guessing "
+    "'client'.\n"
+    "(c) Call search_entities for EVERY party — with its name, and again with any "
+    "register number — BEFORE deciding it is new. The search matches shorter and longer "
+    "forms of a name, and every form already seen for an entity, so a candidate under a "
+    "differently written name is normally the same company. Each candidate carries its "
+    "evidence: match.verdict=same_entity means the estate already holds this entity and "
+    "you must copy its id into existing_id; likely means judge it against the "
+    "identifiers, the matters it appears on and whether it is already on this matter; "
+    "distinct means it carries a conflicting register number and is a different company "
+    "with the same name. A candidate appearing on OTHER matters is normal — a firm "
+    "client has many matters — and is a reason to link, not a reason to create.\n"
+    "(d) Any non-null existing_id MUST be an id returned by search_entities in this "
     "conversation, and a null existing_id is only accepted for a party you actually "
     "searched."
 )

--- a/src/knowledge_index/pipeline/matter_search.py
+++ b/src/knowledge_index/pipeline/matter_search.py
@@ -1,5 +1,6 @@
-"""Ingestion-time matter search: the tools the classification agent uses to link a
-document to one of the firm's existing matters.
+"""Ingestion-time search: the tools the classification and extraction agents use to
+link a document to one of the firm's existing matters, and a named party to one of
+its existing entities.
 
 A firm has hundreds to thousands of matters, so the old "dump the first 80 matters
 into the prompt" approach silently drops most of them. Instead the agent SEARCHES:
@@ -7,16 +8,21 @@ semantically over already-indexed chunks, lexically over matter titles, and by e
 reference number, then reads the folder neighbourhood the way a paralegal would. All
 of this is unscoped by design — classification legitimately needs corpus-wide
 visibility to find the right matter — and never runs on the user query path.
+
+Entity resolution lives here too, and deliberately does NOT share the semantic leg:
+see the block comment above ``EntityCandidate`` for what that cost.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-import re
+import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from knowledge_index.config import AppConfig
@@ -29,9 +35,16 @@ from knowledge_index.db.models import (
     EntityIdentifier,
     Matter,
     MatterAssignment,
+    MatterClient,
+    MatterParty,
     Party,
     Project,
     SourceObject,
+)
+from knowledge_index.entity_names import (
+    name_similarity,
+    name_tokens,
+    normalize_entity_name,
 )
 from knowledge_index.pipeline.folder_context import (
     _parent,
@@ -41,6 +54,8 @@ from knowledge_index.pipeline.folder_context import (
 )
 from knowledge_index.pipeline.providers import AgentTool, embed_text
 from knowledge_index.retrieval_types import Page
+
+log = logging.getLogger(__name__)
 
 # The classification and relation agents see the same pagination contract as the
 # external MCP surface, in fewer words: these agents run per document, thousands
@@ -886,153 +901,796 @@ def classification_tools(
     return tools
 
 
-def search_entities(
-    session: Session, config: AppConfig, query: str, *, limit: int = 8, offset: int = 0
-) -> list[dict]:
-    """Rank the firm's known parties/clients against a free-text name — the entity
-    analogue of search_matters, and semantic-first for the same reason.
+# ---------------------------------------------------------------- entity resolution
+#
+# What the insertion agent used to be given, and why it created 1,212 clients for a
+# corpus whose ground truth is 46. The lexical leg was `Party.name ILIKE '%query%'`,
+# which cannot match "Nexford" against a stored "Nexford Industrial Holdings Inc." in
+# either direction; the primary leg was semantic over already-INDEXED chunks, and
+# `index` is the last pipeline stage, so during a bulk run it is empty exactly when
+# extraction needs it (measured: extraction at 9,122 documents while index stood at
+# 7,033, and near-empty for the first several thousand). The agent searched, was told
+# nothing existed, and created — 973 times for a normalized name the estate already
+# held, 293 of them within 60 seconds of the previous one.
+#
+# So: no leg here depends on the index stage. Identity comes from typed identifiers
+# and from names, matched as token sets over a normalized column with a trigram index
+# behind it. What the semantic leg used to buy — "Nordwind Energie GmbH, Hamburg, HRB
+# 45678" reaching "Nordwind Energie GmbH" — the alias ledger buys instead, and keeps:
+# every surface form that resolves to an entity is recorded on it and matches exactly
+# from then on.
 
-    Primary signal is SEMANTIC: embed the query, take the nearest already-indexed
-    chunks, and surface the entities already resolved on those documents. A party is
-    found by the meaning of where it appears, not by string overlap — so 'Nordwind
-    Energie GmbH' and 'Nordwind Energie GmbH, Hamburg, HRB 45678' reach the same
-    documents and therefore the same candidate, in any language, with no
-    normalization rules. Lexical name and identifier matches are boosts, not the whole
-    search. Skips the semantic leg cleanly on a cold index."""
-    return Page.slice(
-        _ranked_entities(session, config, query), offset=max(0, offset), limit=limit
-    ).items
+# Below this the match is not worth an agent's attention: a single shared generic
+# token, or two names that merely rhyme. Candidates under it are dropped rather than
+# ranked last, so `page.total` counts real candidates.
+_ENTITY_SCORE_FLOOR = 0.35
+
+# A containment match ("Verimark Group" inside "Verimark Hospitality Group Inc.")
+# starts here. Strong enough to link with corroboration, never strong enough alone.
+_ENTITY_LIKELY_SCORE = 0.80
+
+# How many rows one leg may contribute before scoring. A generic token ("holdings")
+# matches half the estate; the floor above sinks those, and this stops the leg from
+# reading the whole table to find out.
+_ENTITY_LEG_LIMIT = 60
+
+# Matter references shown inline on a candidate. The true total rides along as
+# matter_count and the sample says it is one, exactly like peek_matter's titles.
+_ENTITY_MATTER_SAMPLE = 8
+
+_ENTITY_VERDICTS = {
+    "same_entity": (
+        "the estate already holds this entity — reuse its id, do not create a second row"
+    ),
+    "likely": "same name family; link it when the evidence below agrees, else say so",
+    "possible": "a weak name resemblance only",
+    "distinct": (
+        "shares the name but carries a CONFLICTING register identifier — a different "
+        "company with the same name"
+    ),
+}
 
 
-def search_entities_page(
-    session: Session, config: AppConfig, query: str, *, limit: int = 8, offset: int = 0
-) -> Page:
-    """``search_entities`` with an exact candidate total."""
-    return Page.slice(
-        _ranked_entities(session, config, query), offset=max(0, offset), limit=limit
+@dataclass(frozen=True)
+class EntityCandidate:
+    """One already-known entity that might be the one a document just named."""
+
+    entity_type: str  # client | party
+    entity_id: str
+    name: str
+    normalized_name: str
+    kind: str
+    score: float
+    verdict: str
+    components: dict[str, float]
+    matched_identifiers: list[dict]
+    conflicting_identifiers: list[dict]
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.entity_type, self.entity_id)
+
+
+def _entity_identifier_rows(session: Session, entity_type: str, entity_id: str) -> list[dict]:
+    return [
+        {"scheme": row.scheme, "value": row.value}
+        for row in session.scalars(
+            select(EntityIdentifier)
+            .where(
+                EntityIdentifier.entity_type == entity_type,
+                EntityIdentifier.entity_id == entity_id,
+            )
+            .order_by(EntityIdentifier.scheme, EntityIdentifier.value)
+        )
+    ]
+
+
+def _normalize_identifiers(identifiers: dict[str, str] | None) -> dict[str, str]:
+    """The (scheme, value) pairs a mention brings, lowercased and trimmed for comparison."""
+    return {
+        str(scheme).strip().lower(): str(value).strip()
+        for scheme, value in (identifiers or {}).items()
+        if str(value or "").strip()
+    }
+
+
+def _entity_model(entity_type: str):
+    return Client if entity_type == "client" else Party
+
+
+def _candidate_pool(
+    session: Session, query: str, identifiers: dict[str, str] | None
+) -> dict[tuple[str, str], object]:
+    """Every entity worth scoring for this query, from four independent legs.
+
+    Generation is deliberately generous and scoring is strict: a leg that misses is
+    a candidate that can never be found, while a leg that over-fetches only costs
+    rows the score floor then drops.
+    """
+    normalized = normalize_entity_name(query)
+    tokens = sorted(name_tokens(normalized), key=len, reverse=True)[:6]
+    pool: dict[tuple[str, str], object] = {}
+    postgres = session.bind is not None and session.bind.dialect.name == "postgresql"
+
+    def collect(entity_type: str, rows) -> None:
+        for row in rows:
+            pool.setdefault((entity_type, row.id), row)
+
+    # Leg 1 — typed identifiers. A shared register number is proof of identity, so
+    # it must reach the pool whatever the names look like.
+    wanted_values = {value.lower() for value in _normalize_identifiers(identifiers).values()}
+    if query.strip():
+        wanted_values.add(query.strip().lower())
+    if wanted_values:
+        for identifier in session.scalars(
+            select(EntityIdentifier)
+            .where(func.lower(EntityIdentifier.value).in_(sorted(wanted_values)))
+            .order_by(EntityIdentifier.scheme, EntityIdentifier.value, EntityIdentifier.id)
+            .limit(_ENTITY_LEG_LIMIT)
+        ):
+            entity = session.get(_entity_model(identifier.entity_type), identifier.entity_id)
+            if entity is not None:
+                pool.setdefault((identifier.entity_type, entity.id), entity)
+
+    if not normalized:
+        return pool
+
+    for entity_type, model in (("client", Client), ("party", Party)):
+        # Leg 2 — the identity key itself, and the alias ledger. Both are exact
+        # lookups an index answers directly.
+        collect(
+            entity_type,
+            session.scalars(
+                select(model).where(model.normalized_name == normalized).limit(_ENTITY_LEG_LIMIT)
+            ),
+        )
+        if postgres:
+            collect(
+                entity_type,
+                session.scalars(
+                    select(model)
+                    .where(
+                        text(f"{model.__tablename__}.normalized_aliases @> cast(:alias as jsonb)")
+                    )
+                    .params(alias=json.dumps([normalized]))
+                    .limit(_ENTITY_LEG_LIMIT)
+                ),
+            )
+            # Leg 3 — trigram similarity, for the variants nobody has recorded yet:
+            # typos, dropped middle words, transliterations. `%` rides the GIN index
+            # on normalized_name. Doubled because the driver's paramstyle is
+            # `format`: a lone % in raw SQL reads as a placeholder.
+            collect(
+                entity_type,
+                session.scalars(
+                    select(model)
+                    .where(text(f"{model.__tablename__}.normalized_name %% :needle"))
+                    .params(needle=normalized)
+                    .order_by(
+                        func.similarity(model.normalized_name, normalized).desc(), model.id
+                    )
+                    .limit(_ENTITY_LEG_LIMIT)
+                ),
+            )
+        # Leg 4 — one token at a time. This is the leg the old substring predicate
+        # was missing: "Nexford" has to find "Nexford Industrial Holdings Inc." and
+        # be found by it, and trigram similarity between a short name and a long one
+        # is too low to clear any useful threshold. On Postgres the same trigram
+        # index answers these LIKEs.
+        for token in tokens:
+            collect(
+                entity_type,
+                session.scalars(
+                    select(model)
+                    .where(model.normalized_name.like(f"%{token}%"))
+                    .order_by(model.normalized_name, model.id)
+                    .limit(_ENTITY_LEG_LIMIT)
+                ),
+            )
+    return pool
+
+
+def _score_candidate(
+    session: Session,
+    entity_type: str,
+    entity,
+    normalized_query: str,
+    wanted_identifiers: dict[str, str],
+) -> EntityCandidate | None:
+    """Turn one pooled entity into a scored candidate, or drop it below the floor."""
+    held = _entity_identifier_rows(session, entity_type, entity.id)
+    held_by_scheme: dict[str, set[str]] = {}
+    for row in held:
+        held_by_scheme.setdefault(row["scheme"], set()).add(row["value"])
+    matched = [
+        {"scheme": scheme, "value": value}
+        for scheme, value in sorted(wanted_identifiers.items())
+        if value in held_by_scheme.get(scheme, set())
+    ]
+    conflicting = [
+        {"scheme": scheme, "value": sorted(held_by_scheme[scheme])[0]}
+        for scheme, value in sorted(wanted_identifiers.items())
+        if scheme in held_by_scheme and value not in held_by_scheme[scheme]
+    ]
+
+    name_score, component = name_similarity(normalized_query, entity.normalized_name or "")
+    alias_hit = normalized_query and normalized_query in (entity.normalized_aliases or [])
+    if alias_hit and name_score < 1.0:
+        name_score, component = 0.97, "alias"
+    components: dict[str, float] = {}
+    if component:
+        components[component] = name_score
+    if matched:
+        components["identifier"] = 1.0
+
+    if matched:
+        score, verdict = 1.0, "same_entity"
+    elif conflicting:
+        # Same name, contradicting register number. Shown, never linked.
+        score, verdict = name_score, "distinct"
+    elif component == "exact" or alias_hit:
+        score, verdict = max(name_score, 0.97), "same_entity"
+    elif name_score >= _ENTITY_LIKELY_SCORE:
+        score, verdict = name_score, "likely"
+    elif name_score >= _ENTITY_SCORE_FLOOR:
+        score, verdict = name_score, "possible"
+    else:
+        return None
+    return EntityCandidate(
+        entity_type=entity_type,
+        entity_id=entity.id,
+        name=entity.name,
+        normalized_name=entity.normalized_name or "",
+        kind=entity.kind,
+        score=round(score, 4),
+        verdict=verdict,
+        components={key: round(value, 4) for key, value in components.items()},
+        matched_identifiers=matched,
+        conflicting_identifiers=conflicting,
     )
 
 
-def _ranked_entities(session: Session, config: AppConfig, query: str) -> list[dict]:
-    """Every party/client that matched, best first — what the pages are cut from."""
-    query = (query or "").strip()
-    if not query:
+def entity_candidates(
+    session: Session,
+    query: str,
+    *,
+    identifiers: dict[str, str] | None = None,
+) -> list[EntityCandidate]:
+    """Every known client/party that could be ``query``, strongest first.
+
+    The ranking is total and deterministic — score, then entity type, then id — so
+    two calls with the same query cut a page in the same place.
+    """
+    normalized_query = normalize_entity_name(query)
+    wanted = _normalize_identifiers(identifiers)
+    if not normalized_query and not wanted and not (query or "").strip():
         return []
-    scored: dict[tuple[str, str], float] = {}  # (entity_type, id) -> score
+    scored: list[EntityCandidate] = []
+    for (entity_type, _entity_id), entity in _candidate_pool(session, query, identifiers).items():
+        candidate = _score_candidate(session, entity_type, entity, normalized_query, wanted)
+        if candidate is not None:
+            scored.append(candidate)
+    scored.sort(key=lambda item: (-item.score, item.entity_type, item.entity_id))
+    return scored
 
-    # Semantic: nearest already-indexed chunks -> their documents -> the entities
-    # already resolved on those documents.
-    try:
-        from knowledge_index.search_backend import OpenSearchIndex
 
-        vector = embed_text(query, config)
-        for rank, hit in enumerate(OpenSearchIndex(config).matter_hits_by_vector(vector, size=40)):
-            document_id = (hit.get("_source") or {}).get("document_id")
-            document = session.get(Document, document_id) if document_id else None
-            for mention in (document.parties or []) if document else []:
-                entity_id = mention.get("party_id")
-                entity_type = mention.get("entity_type")
-                if entity_id and entity_type:
-                    key = (entity_type, entity_id)
-                    scored[key] = max(scored.get(key, 0.0), 1.0 / (10 + rank))
-    except Exception:
-        pass
+def _entity_matter_ids(session: Session, entity_type: str, entity_id: str) -> list[str]:
+    """The matters an entity already appears on — the evidence that makes a link
+    reviewable, and the reason cross-matter identity is the point: "show me
+    everything for this client" is unanswerable while each matter mints its own copy."""
+    if entity_type == "client":
+        statement = select(MatterClient.matter_id).where(MatterClient.client_id == entity_id)
+    else:
+        statement = select(MatterParty.matter_id).where(MatterParty.party_id == entity_id)
+    return sorted({matter_id for matter_id in session.scalars(statement) if matter_id})
 
-    # Lexical: entity name contains the query (a boost).
-    for party in session.scalars(
-        select(Party)
-        .where(Party.name.ilike(f"%{query}%"))
-        .order_by(Party.name, Party.id)
-        .limit(30)
-    ):
-        scored[("party", party.id)] = scored.get(("party", party.id), 0.0) + 0.5
-    for client in session.scalars(
-        select(Client)
-        .where(Client.name.ilike(f"%{query}%"))
-        .order_by(Client.name, Client.id)
-        .limit(30)
-    ):
-        scored[("client", client.id)] = scored.get(("client", client.id), 0.0) + 0.5
 
-    # Identifier: shared-identifier match (the entity analogue of the matter ref leg).
-    for ident in session.scalars(
-        select(EntityIdentifier)
-        .where(EntityIdentifier.value.ilike(f"%{query}%"))
-        .order_by(EntityIdentifier.value, EntityIdentifier.id)
-        .limit(30)
-    ):
-        key = (ident.entity_type, ident.entity_id)
-        scored[key] = scored.get(key, 0.0) + 1.0
-
-    # (type, id) breaks score ties, so pages cut in the same place every call.
-    ranked = sorted(scored.items(), key=lambda item: (-item[1], item[0]))
-    results: list[dict] = []
-    for (entity_type, entity_id), score in ranked:
-        entity = session.get(Client if entity_type == "client" else Party, entity_id)
-        if entity is None:
-            continue
-        results.append(
-            {
-                "id": entity.id,
-                "entity_type": entity_type,
-                "name": entity.name,
-                "kind": entity.kind,
-                "identifiers": entity.identifiers or {},
-                "match_score": round(score, 4),
-            }
+def _candidate_row(
+    session: Session, candidate: EntityCandidate, *, matter_id: str | None
+) -> dict:
+    """The tool payload for one candidate: what makes it the same entity, not just
+    its name. Counts are exact; the matter list is a named sample of them."""
+    entity = session.get(_entity_model(candidate.entity_type), candidate.entity_id)
+    matter_ids = _entity_matter_ids(session, candidate.entity_type, candidate.entity_id)
+    sample = matter_ids[:_ENTITY_MATTER_SAMPLE]
+    references: list[str] = []
+    for candidate_matter_id in sample:
+        matter = session.get(Matter, candidate_matter_id)
+        if matter is not None:
+            references.append((matter.reference_numbers or [matter.title])[0])
+    document_count = (
+        session.scalar(
+            select(func.count()).select_from(Document).where(Document.matter_id.in_(matter_ids))
         )
-    return results
+        or 0
+        if matter_ids
+        else 0
+    )
+    row = {
+        "id": candidate.entity_id,
+        "entity_type": candidate.entity_type,
+        "name": candidate.name,
+        "kind": candidate.kind,
+        "aliases": list((entity.aliases or []) if entity is not None else []),
+        "identifiers": _entity_identifier_rows(
+            session, candidate.entity_type, candidate.entity_id
+        ),
+        "matched_identifiers": candidate.matched_identifiers,
+        "conflicting_identifiers": candidate.conflicting_identifiers,
+        "matter_count": len(matter_ids),
+        "matter_refs": references,
+        "matter_refs_are_sample": len(matter_ids) > len(sample),
+        "document_count": document_count,
+        "match": {
+            "score": candidate.score,
+            "verdict": candidate.verdict,
+            "means": _ENTITY_VERDICTS[candidate.verdict],
+            "components": candidate.components,
+        },
+    }
+    if matter_id:
+        row["appears_in_this_matter"] = matter_id in matter_ids
+    return row
 
 
-_ENTITY_NAME_SUFFIXES = frozenset(
-    "ag gmbh kg se sa nv bv ab oy plc llp llc lp ltd inc corp co pc pllc "
-    "gbr ohg ug mbh sarl sas spa srl".split()
-)
+def search_entities_page(
+    session: Session,
+    query: str,
+    *,
+    limit: int = 8,
+    offset: int = 0,
+    identifiers: dict[str, str] | None = None,
+    matter_id: str | None = None,
+) -> Page:
+    """One page of ranked candidates, each carrying its evidence.
+
+    Scoring runs over the whole candidate set before the window is cut, so
+    ``offset`` walks one ranking and ``page.total`` is the real number of
+    candidates. The per-row evidence (identifiers, matters, counts) is gathered only
+    for the rows actually returned."""
+    page = Page.slice(
+        entity_candidates(session, query, identifiers=identifiers),
+        offset=max(0, offset),
+        limit=limit,
+    )
+    page.items = [_candidate_row(session, item, matter_id=matter_id) for item in page.items]
+    return page
 
 
-def _normalize_entity_name(text: str) -> str:
-    """Lowercased, punctuation-free, trailing-legal-suffix-free form of a name.
-
-    Used ONLY to judge whether a search_entities query plausibly looked for a
-    party — never to merge entities (merging stays the agent's call, and the
-    deterministic net in ``_resolve_document_parties`` matches verbatim names)."""
-    tokens = re.sub(r"[^\w\s]", " ", (text or "").lower()).split()
-    while tokens and tokens[-1] in _ENTITY_NAME_SUFFIXES:
-        tokens.pop()
-    return " ".join(tokens)
+def search_entities(
+    session: Session,
+    query: str,
+    *,
+    limit: int = 8,
+    offset: int = 0,
+    identifiers: dict[str, str] | None = None,
+    matter_id: str | None = None,
+) -> list[dict]:
+    """``search_entities_page`` without the page block."""
+    return search_entities_page(
+        session,
+        query,
+        limit=limit,
+        offset=offset,
+        identifiers=identifiers,
+        matter_id=matter_id,
+    ).items
 
 
 def entity_search_covered(name: str, searched_queries: set[str]) -> bool:
     """True when one of the agent's search_entities queries covered this party:
-    after normalization, one string contains the other ("Vantage Prime Bank"
+    after normalization, one name's tokens contain the other's ("Vantage Prime Bank"
     covers "Vantage Prime Bank AG"). A name that normalizes to nothing needs no
     search."""
-    normalized = _normalize_entity_name(name)
+    normalized = normalize_entity_name(name)
     if not normalized:
         return True
+    wanted = name_tokens(normalized)
     for query in searched_queries:
-        candidate = _normalize_entity_name(query)
-        if candidate and (candidate in normalized or normalized in candidate):
+        candidate = name_tokens(normalize_entity_name(query))
+        if candidate and (candidate <= wanted or wanted <= candidate):
             return True
     return False
 
 
+# ------------------------------------------------------------ creation without twins
+
+
+def _entity_alias_ledger(entity, surface_name: str) -> None:
+    """Record a surface form on the entity it resolved to.
+
+    This is how the corpus teaches the resolver: the second document that writes
+    "Nordwind Energie GmbH, Hamburg" resolves fuzzily, and every one after it
+    resolves exactly."""
+    normalized = normalize_entity_name(surface_name)
+    if not normalized or normalized == (entity.normalized_name or ""):
+        return
+    aliases = list(entity.aliases or [])
+    normalized_aliases = list(entity.normalized_aliases or [])
+    if normalized in normalized_aliases:
+        return
+    normalized_aliases.append(normalized)
+    if surface_name.strip() and surface_name.strip() not in aliases:
+        aliases.append(surface_name.strip())
+    # Reassigned rather than mutated: a JSON column tracks identity, not contents.
+    entity.aliases = aliases
+    entity.normalized_aliases = normalized_aliases
+
+
+def _corroboration(
+    session: Session,
+    candidate: EntityCandidate,
+    *,
+    matter_id: str | None,
+    sibling_entity_ids: set[str],
+) -> list[str]:
+    """Reasons beyond the name to believe a ``likely`` candidate is this entity.
+
+    A shared identifier is proof and never reaches here. These are the signals that
+    turn a strong name match into a link instead of a question: the entity is
+    already on this matter, or it shares a matter with somebody else this very
+    document names, or it acts for the same client this matter does."""
+    reasons: list[str] = []
+    matter_ids = set(_entity_matter_ids(session, candidate.entity_type, candidate.entity_id))
+    if matter_id and matter_id in matter_ids:
+        reasons.append("already_on_this_matter")
+    if matter_ids and sibling_entity_ids:
+        co_occurring = (
+            session.scalar(
+                select(func.count())
+                .select_from(MatterParty)
+                .where(
+                    MatterParty.matter_id.in_(matter_ids),
+                    MatterParty.party_id.in_(sibling_entity_ids),
+                )
+            )
+            or 0
+        ) + (
+            session.scalar(
+                select(func.count())
+                .select_from(MatterClient)
+                .where(
+                    MatterClient.matter_id.in_(matter_ids),
+                    MatterClient.client_id.in_(sibling_entity_ids),
+                )
+            )
+            or 0
+        )
+        if co_occurring:
+            reasons.append("shares_a_matter_with_another_party_on_this_document")
+    if matter_id and matter_ids:
+        this_matter_clients = set(
+            session.scalars(
+                select(MatterClient.client_id).where(MatterClient.matter_id == matter_id)
+            )
+        )
+        if this_matter_clients:
+            shared_client = session.scalar(
+                select(func.count())
+                .select_from(MatterClient)
+                .where(
+                    MatterClient.matter_id.in_(matter_ids - {matter_id}),
+                    MatterClient.client_id.in_(this_matter_clients),
+                )
+            )
+            if shared_client:
+                reasons.append("acts_on_another_matter_for_this_matter_s_client")
+    return reasons
+
+
+def link_decision(
+    session: Session,
+    candidates: list[EntityCandidate],
+    *,
+    entity_type: str,
+    matter_id: str | None,
+    sibling_entity_ids: set[str],
+) -> tuple[EntityCandidate | None, str, list[str]]:
+    """THE RULE, in one place, so it can be read, argued with, and tested.
+
+    A mention links to an entity the estate already holds when:
+
+    1. they share a typed identifier — proof, and it outranks every name signal;
+    2. the normalized names are identical, or the mention's name is already on the
+       entity's alias ledger, and no register identifier contradicts it. This is the
+       default path across matters, not a judgement the agent may decline: a firm
+       client has many matters, and 1,076 of 1,212 clients touching exactly one
+       matter is the inverse of what a firm looks like;
+    3. one name contains the other token-for-token AND something beyond the name
+       agrees (see ``_corroboration``).
+
+    Everything else escalates: the candidates go back to the agent with their
+    evidence and it decides. Creating alongside a candidate is allowed — different
+    companies genuinely share names — but it is recorded on the new row's
+    provenance, so "created a second entity for a name the estate already knows" is
+    a countable event rather than a suspicion.
+
+    Returns ``(entity, reason, corroboration)``; ``entity`` is None when nothing
+    links automatically.
+    """
+    same_type = [item for item in candidates if item.entity_type == entity_type]
+    ordered = same_type + [item for item in candidates if item.entity_type != entity_type]
+    for candidate in ordered:
+        if candidate.matched_identifiers:
+            return candidate, "shared_identifier", []
+    for candidate in ordered:
+        if candidate.verdict == "same_entity":
+            return candidate, "normalized_name", []
+    for candidate in ordered:
+        if candidate.verdict != "likely":
+            continue
+        reasons = _corroboration(
+            session, candidate, matter_id=matter_id, sibling_entity_ids=sibling_entity_ids
+        )
+        if reasons:
+            return candidate, "name_and_corroboration", reasons
+    return None, "no_confident_candidate", []
+
+
+def _identity_discriminator(
+    candidates: list[EntityCandidate], identifiers: dict[str, str]
+) -> str:
+    """What makes a new row a legitimately DIFFERENT entity from a same-named one.
+
+    Empty for almost everything. Non-empty only when the estate already holds this
+    normalized name and this mention carries a register identifier that contradicts
+    it — the one case where two rows with one name are the truth rather than the
+    bug, and the only thing the unique constraint will let through."""
+    conflicting = [item for item in candidates if item.conflicting_identifiers]
+    if not conflicting or not identifiers:
+        return ""
+    scheme, value = sorted(identifiers.items())[0]
+    return f"{scheme}:{value}"
+
+
+def resolve_or_create_entity(
+    session_factory: sessionmaker[Session],
+    *,
+    entity_type: str,
+    name: str,
+    kind: str,
+    identifiers: dict[str, str],
+    provenance: dict,
+    matter_id: str | None = None,
+    sibling_entity_ids: set[str] | None = None,
+    preferred_entity_id: str | None = None,
+) -> dict:
+    """Resolve one named party to exactly one row, committed before this returns.
+
+    Its own short session, for the same reason ``get_or_create_matter`` has one:
+    thousands of documents extract in parallel and the entity has to become visible
+    to the others the moment it exists, not when the calling stage's transaction
+    commits minutes later. That alone removes the pure race — 293 of the 973
+    duplicate creations happened within 60 seconds of the previous one.
+
+    Two further guards, because "unlikely" is not "impossible":
+    the advisory lock on the normalized name makes search-then-create atomic per
+    name, and the unique constraint on (normalized_name, identity_discriminator)
+    catches anything that reaches an insert anyway — a lock-key hash collision, a
+    non-Postgres deployment, a future caller that forgets — by turning the losing
+    insert into a re-select of the winner.
+    """
+    surface = (name or "").strip()
+    normalized = normalize_entity_name(surface)
+    identifiers = _normalize_identifiers(identifiers)
+    with session_factory() as session:
+        _advisory_xact_lock(session, f"entity:{entity_type}:{normalized}")
+        candidates = entity_candidates(session, surface, identifiers=identifiers)
+        entity, reason, corroboration = link_decision(
+            session,
+            candidates,
+            entity_type=entity_type,
+            matter_id=matter_id,
+            sibling_entity_ids=sibling_entity_ids or set(),
+        )
+        resolved = None
+        resolved_type = entity_type
+        if entity is not None:
+            resolved = session.get(_entity_model(entity.entity_type), entity.entity_id)
+            resolved_type = entity.entity_type
+        elif preferred_entity_id:
+            # The agent named a candidate the deterministic rule did not reach. It
+            # saw the evidence; honour it, and say which one said so. It may well have
+            # named a row from the other table — the same company is the client here
+            # and the counterparty there — so both are checked.
+            other_type = "party" if entity_type == "client" else "client"
+            for entity_type_candidate in (entity_type, other_type):
+                resolved = session.get(_entity_model(entity_type_candidate), preferred_entity_id)
+                if resolved is not None:
+                    resolved_type = entity_type_candidate
+                    reason = "agent_link"
+                    break
+        if resolved is not None:
+            if resolved_type != entity_type:
+                # The same real-world entity is the firm's client on one matter and a
+                # counterparty on another; the two live in different tables. Carry the
+                # identity across instead of minting an unrelated row for the twin.
+                resolved = _mirror_entity(
+                    session, resolved, entity_type=entity_type, provenance=provenance
+                )
+            _entity_alias_ledger(resolved, surface)
+            for scheme, value in identifiers.items():
+                _ensure_identifier(session, entity_type, resolved.id, scheme, value)
+            session.commit()
+            return {
+                "id": resolved.id,
+                "entity_type": entity_type,
+                "created": False,
+                "reason": reason,
+                "corroboration": corroboration,
+            }
+
+        model = _entity_model(entity_type)
+        discriminator = _identity_discriminator(candidates, identifiers)
+        shadowed = [
+            {"id": item.entity_id, "name": item.name, "score": item.score, "verdict": item.verdict}
+            for item in candidates[:5]
+        ]
+        record = dict(provenance)
+        record["resolution"] = {
+            "decision": "created",
+            "reason": reason,
+            # Countable: `select count(*) from clients where
+            # provenance #>> '{resolution,reason}' <> 'no_confident_candidate'`
+            # is the number of times insertion made a second row for a name the
+            # estate already knew.
+            "shadowed_candidates": shadowed,
+        }
+        entity_row = model(
+            name=surface,
+            kind=kind,
+            aliases=[],
+            normalized_aliases=[],
+            identity_discriminator=discriminator,
+            identifiers=dict(identifiers),
+            provenance=record,
+        )
+        session.add(entity_row)
+        try:
+            session.flush()
+        except IntegrityError as conflict:
+            session.rollback()
+            return _reselect_after_conflict(
+                session_factory,
+                conflict,
+                entity_type=entity_type,
+                normalized=normalized,
+                discriminator=discriminator,
+                surface=surface,
+                identifiers=identifiers,
+            )
+        for scheme, value in identifiers.items():
+            _ensure_identifier(session, entity_type, entity_row.id, scheme, value)
+        session.commit()
+        if shadowed:
+            log.info(
+                "entity created alongside %d known candidate(s): %r (%s)",
+                len(shadowed),
+                surface,
+                entity_type,
+            )
+        return {
+            "id": entity_row.id,
+            "entity_type": entity_type,
+            "created": True,
+            "reason": reason,
+            "corroboration": [],
+        }
+
+
+def _reselect_after_conflict(
+    session_factory: sessionmaker[Session],
+    conflict: IntegrityError,
+    *,
+    entity_type: str,
+    normalized: str,
+    discriminator: str,
+    surface: str,
+    identifiers: dict[str, str],
+) -> dict:
+    """The loser of a race reads the winner's row instead of raising.
+
+    Reached only when two creators got past the advisory lock — a non-Postgres
+    deployment, or a key collision. The constraint decided; this reports what it
+    decided."""
+    model = _entity_model(entity_type)
+    with session_factory() as session:
+        winner = session.scalar(
+            select(model).where(
+                model.normalized_name == normalized,
+                model.identity_discriminator == discriminator,
+            )
+        )
+        if winner is None:  # pragma: no cover - the constraint fired for another reason
+            raise conflict
+        _entity_alias_ledger(winner, surface)
+        for scheme, value in identifiers.items():
+            _ensure_identifier(session, entity_type, winner.id, scheme, value)
+        session.commit()
+        return {
+            "id": winner.id,
+            "entity_type": entity_type,
+            "created": False,
+            "reason": "lost_creation_race",
+            "corroboration": [],
+        }
+
+
+def _mirror_entity(session: Session, source, *, entity_type: str, provenance: dict):
+    """The counterpart row for an entity that is a client here and a party there.
+
+    Clients and parties are separate tables by design (docs/concepts/data-model.md),
+    so one company can need a row in each. It gets the same name, aliases and
+    identifiers, so both rows resolve from either spelling and the pair is
+    recognizable as one entity rather than as two unrelated ones."""
+    model = _entity_model(entity_type)
+    existing = session.scalar(
+        select(model).where(
+            model.normalized_name == source.normalized_name,
+            model.identity_discriminator == source.identity_discriminator,
+        )
+    )
+    if existing is not None:
+        return existing
+    record = dict(provenance)
+    record["resolution"] = {"decision": "mirrored", "from": source.id}
+    mirror = model(
+        name=source.name,
+        kind=source.kind,
+        aliases=list(source.aliases or []),
+        normalized_aliases=list(source.normalized_aliases or []),
+        identity_discriminator=source.identity_discriminator,
+        identifiers=dict(source.identifiers or {}),
+        provenance=record,
+    )
+    session.add(mirror)
+    session.flush()
+    for row in _entity_identifier_rows(session, "client" if entity_type == "party" else "party", source.id):
+        _ensure_identifier(session, entity_type, mirror.id, row["scheme"], row["value"])
+    return mirror
+
+
+def _ensure_identifier(
+    session: Session, entity_type: str, entity_id: str, scheme: str, value: str
+) -> None:
+    """Idempotent promotion of one typed identifier onto an entity."""
+    scheme = str(scheme).strip().lower()
+    value = str(value).strip()
+    if not scheme or not value:
+        return
+    exists = session.scalar(
+        select(EntityIdentifier).where(
+            EntityIdentifier.entity_type == entity_type,
+            EntityIdentifier.entity_id == entity_id,
+            EntityIdentifier.scheme == scheme,
+            EntityIdentifier.value == value,
+        )
+    )
+    if exists is None:
+        session.add(
+            EntityIdentifier(
+                entity_type=entity_type, entity_id=entity_id, scheme=scheme, value=value
+            )
+        )
+
+
 def party_resolution_tools(
     session: Session,
-    config: AppConfig,
     seen_ids: set[str],
     searched_queries: set[str] | None = None,
+    *,
+    matter_id: str | None = None,
 ) -> list[AgentTool]:
-    """The tool the extraction agent uses to resolve a party to a firm-wide entity:
-    search the firm's known parties/clients (semantic-first, exactly like
-    search_matters), then the agent links (reuses an id) or creates a new one.
+    """The tool the extraction agent uses to resolve a party to a firm-wide entity.
 
     ``seen_ids`` accumulates every id the agent is shown, so the stage can reject an
-    existing_id the agent never actually saw (the "name alone is not enough" guard).
-    ``searched_queries`` accumulates every query the agent ran, so the stage can
-    equally reject a CREATE for a party the agent never searched — without it,
-    create is the frictionless default and the entity layer fills with twins
-    (the 2026-08-01 audit: 63% duplicate party rows, 23.7% reuse)."""
+    existing_id the agent never actually saw. ``searched_queries`` accumulates every
+    query it ran, so the stage can equally reject a CREATE for a party it never
+    searched — without that, create is the frictionless default.
+
+    Neither guard was ever the weak link, though. The tool told the truth about a
+    search that could not find what it was looking for, and the agent believed it.
+    """
 
     def _search(args: dict) -> str:
         needle = str(args.get("query", "")).strip()
@@ -1041,10 +1699,10 @@ def party_resolution_tools(
         page = (
             search_entities_page(
                 session,
-                config,
                 needle,
                 limit=int(args.get("limit", 8) or 8),
                 offset=int(args.get("offset", 0) or 0),
+                matter_id=matter_id,
             )
             if needle
             else Page()
@@ -1057,17 +1715,19 @@ def party_resolution_tools(
         AgentTool(
             name="search_entities",
             description=(
-                "Search the firm's already-known parties and clients. Ranks by semantic "
-                "similarity of where entities appear, plus name and identifier matches. "
-                "Returns candidates with id, entity_type (party|client), name, kind and "
-                "identifiers. Call it before deciding a party is new: reuse a candidate's "
-                "id (as existing_id) ONLY when it is genuinely the same real-world entity "
-                "— a matching name alone is not enough, because different companies share "
-                "names."
+                "Search the firm's already-known parties and clients by name or register "
+                "identifier. Matching is on the normalized name, so a shorter or longer "
+                "form of the same name still finds it ('Nexford' finds 'Nexford Industrial "
+                "Holdings Inc.'), and every name form already seen for an entity is "
+                "searchable too. Each candidate arrives with the evidence: matching and "
+                "conflicting identifiers, how many matters it appears on and which, "
+                "whether it is already on THIS document's matter, and match.verdict — "
+                "same_entity means the estate already holds it, so reuse its id; likely "
+                "means judge it against the evidence; distinct means it shares the name "
+                "but carries a conflicting register number and is a different company."
                 + _AGENT_PAGINATION
-                + " Creating a duplicate of an entity that was simply on page 2 is the "
-                "most expensive mistake here, so check has_more before deciding a party "
-                "is new."
+                + " A firm client appears across many matters, so finding a candidate on "
+                "another matter is normal and is a reason to link, not a reason to create."
             ),
             parameters={
                 "type": "object",

--- a/src/knowledge_index/pipeline/matter_search.py
+++ b/src/knowledge_index/pipeline/matter_search.py
@@ -1622,14 +1622,26 @@ def _mirror_entity(session: Session, source, *, entity_type: str, provenance: di
     Clients and parties are separate tables by design (docs/concepts/data-model.md),
     so one company can need a row in each. It gets the same name, aliases and
     identifiers, so both rows resolve from either spelling and the pair is
-    recognizable as one entity rather than as two unrelated ones."""
+    recognizable as one entity rather than as two unrelated ones.
+
+    This is an insert like any other, so it degrades the same way. The advisory lock
+    upstream is keyed on the MENTION's normalized name, and the entity this mirrors
+    can have reached the mention by an alias or a corroborated partial match — so two
+    resolvers can be here for one company at once without ever contending. The
+    constraint settles it; the savepoint is what lets the loser keep the transaction
+    it is standing in and read the winner instead of failing the document."""
     model = _entity_model(entity_type)
-    existing = session.scalar(
-        select(model).where(
-            model.normalized_name == source.normalized_name,
-            model.identity_discriminator == source.identity_discriminator,
+    source_type = "client" if entity_type == "party" else "party"
+
+    def _existing():
+        return session.scalar(
+            select(model).where(
+                model.normalized_name == source.normalized_name,
+                model.identity_discriminator == source.identity_discriminator,
+            )
         )
-    )
+
+    existing = _existing()
     if existing is not None:
         return existing
     record = dict(provenance)
@@ -1643,9 +1655,16 @@ def _mirror_entity(session: Session, source, *, entity_type: str, provenance: di
         identifiers=dict(source.identifiers or {}),
         provenance=record,
     )
-    session.add(mirror)
-    session.flush()
-    for row in _entity_identifier_rows(session, "client" if entity_type == "party" else "party", source.id):
+    try:
+        with session.begin_nested():
+            session.add(mirror)
+            session.flush()
+    except IntegrityError:
+        winner = _existing()
+        if winner is None:  # pragma: no cover - the constraint fired for another reason
+            raise
+        return winner
+    for row in _entity_identifier_rows(session, source_type, source.id):
         _ensure_identifier(session, entity_type, mirror.id, row["scheme"], row["value"])
     return mirror
 

--- a/src/knowledge_index/pipeline/runner.py
+++ b/src/knowledge_index/pipeline/runner.py
@@ -31,7 +31,6 @@ from knowledge_index.db.models import (
     DocumentGrant,
     DocumentVersion,
     DocumentVersionSource,
-    EntityIdentifier,
     Extraction,
     Matter,
     MatterAssignment,
@@ -73,11 +72,13 @@ from knowledge_index.pipeline.folder_context import (
     build_member_doc,
     folder_ls,
 )
+from knowledge_index.entity_names import normalize_entity_name
 from knowledge_index.pipeline.matter_search import (
     classification_tools,
     entity_search_covered,
     party_resolution_tools,
     relation_tools,
+    resolve_or_create_entity,
 )
 from knowledge_index.pipeline.providers import (
     ModelOutputInvalid,
@@ -1979,11 +1980,12 @@ class PipelineRunner:
                     )
                 if node not in clause_scope.visible:
                     return f"clause_type_node {node!r} is not part of the active clause facet"
-            # A linked party must be one the agent actually saw via search_entities —
-            # the "a matching name is not enough" guard against merging two entities.
-            # And symmetrically: a NEW party is only accepted when the agent actually
-            # searched for it — without this, create is the frictionless default and
-            # the entity layer fills with same-name twins instead of resolutions.
+            # Both guards are about what the agent SAW, not about what is stored: a
+            # submitted existing_id has to come from a search result, and a party the
+            # agent never searched for cannot be asserted as new. Whether two names
+            # are one entity is decided afterwards, by rule, in
+            # _resolve_document_parties — so neither of these is load-bearing for
+            # deduplication any more, and neither ever was.
             for party in candidate.parties:
                 if party.existing_id and party.existing_id not in seen_ids:
                     return (
@@ -2006,7 +2008,9 @@ class PipelineRunner:
         if clause_scope is not None:
             tools.append(clause_search_tool(clause_scope, clause_visited))
         tools.extend(
-            party_resolution_tools(session, self.config, seen_ids, searched_queries)
+            party_resolution_tools(
+                session, seen_ids, searched_queries, matter_id=document.matter_id
+            )
         )
         metadata = chat_agent(
             model,
@@ -2070,7 +2074,13 @@ class PipelineRunner:
             doc_date_source = "none"
         document.title = metadata.title or document.title
         document.parties = _resolve_document_parties(
-            session, document, metadata.parties, model=model, evidence=source_object.id
+            session,
+            document,
+            metadata.parties,
+            model=model,
+            evidence=source_object.id,
+            session_factory=self.session_factory,
+            config=self.config,
         )
         document.identifiers = sorted(
             {value.strip() for value in metadata.identifiers if value.strip()}
@@ -2443,6 +2453,58 @@ def connector_from_source(source: Source, session: Session | None = None) -> Syn
     return LocalFilesystemSource(config["root"], acl_resolver=acl_resolver if has_acl else None)
 
 
+def _effective_party_role(
+    session: Session,
+    matter: Matter | None,
+    party: ExtractedParty,
+    role: str,
+    config: AppConfig,
+) -> tuple[str, str | None]:
+    """The role a mention actually gets, and why it is not the one claimed.
+
+    ``client`` does not mean "an important company on this page" — it means the party
+    THIS FIRM acts for on THIS matter. The 9,288-document run had 985 distinct names
+    carrying it, including individuals, counterparties, co-investors, and the firm
+    itself 16 times. Three refusals, none of them a prompt:
+
+    * the firm is never its own client (config.firm; off when unset, because an
+      appliance that has not been told whose it is cannot recognise its own name);
+    * an entity already recorded as a party on this matter keeps the role it has —
+      nobody is the opposing party and the client of the same matter;
+    * a matter whose client came from practice management is authoritative, so a
+      document-level claim that disagrees is recorded as a named party instead.
+    """
+    if role != PartyRole.CLIENT.value:
+        return role, None
+    if config.firm.is_self(party.name):
+        # Recorded as the advising law firm, which is what it is, rather than dropped:
+        # it IS on the document.
+        return PartyRole.ADVISOR.value, "own_firm"
+    if matter is None:
+        return role, None
+    normalized = normalize_entity_name(party.name)
+    incumbent = session.scalar(
+        select(MatterParty.role)
+        .join(Party, Party.id == MatterParty.party_id)
+        .where(MatterParty.matter_id == matter.id, Party.normalized_name == normalized)
+        .order_by(MatterParty.role)
+        .limit(1)
+    )
+    if incumbent:
+        return incumbent, "already_a_party_on_this_matter"
+    if matter.imported:
+        authoritative = set(
+            session.scalars(
+                select(Client.normalized_name)
+                .join(MatterClient, MatterClient.client_id == Client.id)
+                .where(MatterClient.matter_id == matter.id)
+            )
+        )
+        if authoritative and normalized not in authoritative:
+            return PartyRole.OTHER.value, "matter_client_is_authoritative"
+    return role, None
+
+
 def _resolve_document_parties(
     session: Session,
     document: Document,
@@ -2450,102 +2512,85 @@ def _resolve_document_parties(
     *,
     model: str,
     evidence: str,
+    session_factory: sessionmaker[Session],
+    config: AppConfig,
 ) -> list[dict]:
-    """Materialize the agent's resolved parties into the firm-wide entity layer.
+    """Materialize the document's named parties into the firm-wide entity layer.
 
-    Resolution is the AGENT's: it either LINKED to an existing entity (set existing_id,
-    which the stage validator confirmed it saw via search_entities) or decided CREATE.
-    One deterministic safety net backs the agent up: a CREATE whose verbatim name this
-    matter already knows (case-insensitively) reuses that entity instead of minting a
-    twin — same-name entities in DIFFERENT matters stay distinct on purpose, since
-    different companies share names and that ambiguity is genuinely the agent's call.
-    The firm's client (role=client) lands in ``clients`` + ``matter_clients``; every
-    other party lands in ``parties`` + ``matter_parties``. Typed identifiers are
-    promoted to ``entity_identifiers``. Link writes are idempotent via the composite
-    PKs. Returns the ``document.parties`` payload with each mention's resolved entity
-    id.
+    Resolution is NOT the agent's to decline. It searched, and it may have linked by
+    id; but whether two names are one entity is a rule (see
+    ``matter_search.link_decision``), applied here to every mention regardless of what
+    the agent submitted. That is the difference between a client with five matters and
+    five clients with one matter each, and the corpus this was measured on had 1,076 of
+    1,212 clients touching exactly one matter where the ground truth is 46 clients
+    across 266 matters.
+
+    Each entity is resolved-or-created in its OWN committed transaction, so a sibling
+    document extracting the same party in parallel sees it immediately instead of
+    creating its own copy minutes later. The matter links written here belong to this
+    stage's transaction, because they are facts about this document.
+
+    Returns the ``document.parties`` payload with each mention's resolved entity id.
     """
     matter_id = document.matter_id
+    matter = session.get(Matter, matter_id) if matter_id else None
     provenance = {"method": "inferred", "model": model, "evidence": [evidence]}
     resolved: list[dict] = []
+    # Entities already resolved on THIS document corroborate the next one: a
+    # candidate that shares a matter with a party named beside it here is very
+    # likely the same entity as the name that reached it.
+    siblings: set[str] = set()
+    # Now that two mentions of one name resolve to ONE entity, a document naming it
+    # twice reaches the same link twice; session.get cannot see the first one while
+    # it is still pending, so the pair is remembered here instead.
+    linked: set[tuple[str, str]] = set()
     for party in parties:
-        role = party.role.value if isinstance(party.role, PartyRole) else str(party.role)
+        claimed = party.role.value if isinstance(party.role, PartyRole) else str(party.role)
+        role, demotion = _effective_party_role(session, matter, party, claimed, config)
         is_client = role == PartyRole.CLIENT.value
         entity_type = "client" if is_client else "party"
-        model_cls = Client if is_client else Party
+        outcome = resolve_or_create_entity(
+            session_factory,
+            entity_type=entity_type,
+            name=party.name,
+            kind=party.kind,
+            identifiers={ident.scheme: ident.value for ident in party.identifiers},
+            provenance=provenance,
+            matter_id=matter_id,
+            sibling_entity_ids=siblings,
+            preferred_entity_id=party.existing_id,
+        )
+        entity_id = outcome["id"]
+        siblings.add(entity_id)
 
-        entity = session.get(model_cls, party.existing_id) if party.existing_id else None
-        if entity is None and matter_id:
-            normalized_name = party.name.strip().lower()
+        if matter_id and (entity_id, role) not in linked:
+            linked.add((entity_id, role))
             if is_client:
-                entity = session.scalar(
-                    select(Client)
-                    .join(MatterClient, MatterClient.client_id == Client.id)
-                    .where(
-                        MatterClient.matter_id == matter_id,
-                        func.lower(func.trim(Client.name)) == normalized_name,
-                    )
-                    .limit(1)
-                )
-            else:
-                entity = session.scalar(
-                    select(Party)
-                    .join(MatterParty, MatterParty.party_id == Party.id)
-                    .where(
-                        MatterParty.matter_id == matter_id,
-                        func.lower(func.trim(Party.name)) == normalized_name,
-                    )
-                    .limit(1)
-                )
-        if entity is None:
-            entity = model_cls(
-                name=party.name,
-                kind=party.kind,
-                aliases=[],
-                identifiers={ident.scheme: ident.value for ident in party.identifiers},
-                provenance=provenance,
-            )
-            session.add(entity)
-            session.flush()
-
-        if matter_id:
-            if is_client:
-                if session.get(MatterClient, (matter_id, entity.id)) is None:
-                    session.add(MatterClient(matter_id=matter_id, client_id=entity.id))
-            elif session.get(MatterParty, (matter_id, entity.id, role)) is None:
+                if session.get(MatterClient, (matter_id, entity_id)) is None:
+                    session.add(MatterClient(matter_id=matter_id, client_id=entity_id))
+            elif session.get(MatterParty, (matter_id, entity_id, role)) is None:
                 session.add(
                     MatterParty(
                         matter_id=matter_id,
-                        party_id=entity.id,
+                        party_id=entity_id,
                         role=role,
                         provenance=provenance,
                     )
                 )
-        for ident in party.identifiers:
-            _ensure_entity_identifier(session, entity_type, entity.id, ident.scheme, ident.value)
-        resolved.append(
-            {"name": party.name, "role": role, "entity_type": entity_type, "party_id": entity.id}
-        )
+        mention = {
+            "name": party.name,
+            "role": role,
+            "entity_type": entity_type,
+            "party_id": entity_id,
+            "resolution": outcome["reason"],
+        }
+        if demotion:
+            # The claim is kept next to the refusal: an operator reading this row
+            # should see what the model said, not only what was stored.
+            mention["claimed_role"] = claimed
+            mention["role_refused_because"] = demotion
+        resolved.append(mention)
     return resolved
-
-
-def _ensure_entity_identifier(
-    session: Session, entity_type: str, entity_id: str, scheme: str, value: str
-) -> None:
-    exists = session.scalar(
-        select(EntityIdentifier).where(
-            EntityIdentifier.entity_type == entity_type,
-            EntityIdentifier.entity_id == entity_id,
-            EntityIdentifier.scheme == scheme,
-            EntityIdentifier.value == value,
-        )
-    )
-    if exists is None:
-        session.add(
-            EntityIdentifier(
-                entity_type=entity_type, entity_id=entity_id, scheme=scheme, value=value
-            )
-        )
 
 def _close_connectors(connectors: dict) -> None:
     for connector in connectors.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,9 @@ def _ensure_database(*, recreate: bool) -> None:
     try:
         with engine.connect() as connection:
             connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            # The entity resolver's name search rides a trigram GIN index, so
+            # create_all cannot build the clients/parties schema without pg_trgm.
+            connection.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
             connection.commit()
         Base.metadata.create_all(engine)
     finally:

--- a/tests/test_agent_tool_pagination.py
+++ b/tests/test_agent_tool_pagination.py
@@ -163,7 +163,7 @@ def test_search_entities_tool_pages(factory) -> None:
     session = factory()
     try:
         seen: set[str] = set()
-        tool = party_resolution_tools(session, AppConfig(), seen)[0]
+        tool = party_resolution_tools(session, seen)[0]
         payload = json.loads(tool.handler({"query": "Nordwind", "limit": 4}))
         assert len(payload["results"]) == 4
         assert payload["page"]["has_more"] is True

--- a/tests/test_entity_creation_race.py
+++ b/tests/test_entity_creation_race.py
@@ -96,6 +96,36 @@ def test_racing_creations_of_different_entities_all_land(
     assert len({item["id"] for item in results}) == 8
 
 
+def test_two_bare_legal_forms_are_not_one_company(factory: sessionmaker[Session]) -> None:
+    """The constraint's failure mode, tested from the other side.
+
+    An extraction agent that leaves a mention as its bare form gives the resolver a
+    name with nothing but legal-form tokens in it. If those strip to an empty key,
+    every such mention keys identically and the constraint stops being a guard against
+    twins and starts being a merge of unrelated companies — the exact harm this change
+    exists to prevent, inverted.
+    """
+    first = resolve_or_create_entity(
+        factory,
+        entity_type="party",
+        name="GmbH & Co. KG",
+        kind="legal_entity",
+        identifiers={},
+        provenance=PROVENANCE,
+    )
+    second = resolve_or_create_entity(
+        factory,
+        entity_type="party",
+        name="The Company",
+        kind="legal_entity",
+        identifiers={},
+        provenance=PROVENANCE,
+    )
+    assert first["id"] != second["id"]
+    with factory() as session:
+        assert session.scalar(select(func.count()).select_from(Party)) == 2
+
+
 def test_the_constraint_refuses_a_twin_even_without_the_lock(
     session: Session, factory: sessionmaker[Session]
 ) -> None:
@@ -112,6 +142,37 @@ def test_the_constraint_refuses_a_twin_even_without_the_lock(
     with pytest.raises(IntegrityError):
         session.flush()
     session.rollback()
+
+
+def test_the_counterpart_row_is_raced_for_too(factory: sessionmaker[Session]) -> None:
+    """A company that is a counterparty on one matter and the client on another needs a
+    row in each table, and that second row is an insert like any other.
+
+    The advisory lock cannot serialize these: it is keyed on the MENTION's normalized
+    name, and three mentions reaching one entity through its alias ledger hold three
+    different keys. So the constraint is what decides, and the losers have to come back
+    with the winner rather than failing their documents.
+    """
+    with factory() as session:
+        session.add(
+            Party(
+                name="Nordwind Energie GmbH",
+                kind="legal_entity",
+                normalized_aliases=["nordwind energie hamburg", "nordwind energie bremen"],
+            )
+        )
+        session.commit()
+
+    results = _race(
+        factory,
+        ["Nordwind Energie", "Nordwind Energie GmbH, Hamburg", "Nordwind Energie, Bremen"],
+        "client",
+    )
+
+    assert len({item["id"] for item in results}) == 1
+    with factory() as session:
+        assert session.scalar(select(func.count()).select_from(Client)) == 1
+        assert session.scalar(select(func.count()).select_from(Party)) == 1
 
 
 def test_a_creator_that_loses_the_insert_reads_the_winner(

--- a/tests/test_entity_creation_race.py
+++ b/tests/test_entity_creation_race.py
@@ -1,0 +1,151 @@
+"""Concurrent creation of the same entity, actually raced.
+
+30% of the duplicate client rows on the 9,288-document run (293 of 973) were created
+within 60 seconds of the row they duplicated: documents extracting in parallel each
+searched, each was told nothing existed, and each created. A test that calls the
+resolver twice in sequence cannot see that bug, so these run real threads against the
+real database and assert on the row count afterwards.
+
+Three independent guards, tested one at a time:
+the short committed transaction (the entity is visible the moment it exists), the
+advisory lock on the normalized name (search-then-create is atomic), and the unique
+constraint (whatever gets past the first two loses the insert and re-reads the winner).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from knowledge_index.db.models import Client, Party
+from knowledge_index.pipeline import matter_search
+from knowledge_index.pipeline.matter_search import resolve_or_create_entity
+
+PROVENANCE = {"method": "inferred", "model": "test-model", "evidence": ["ev-1"]}
+
+# One name, written the way twelve different documents would write it. All of them
+# are the same company and must end up as one row.
+VARIANTS = [
+    "Velthryn Strategic Investments, LP",
+    "Velthryn Strategic Investments LP",
+    "VELTHRYN STRATEGIC INVESTMENTS, L.P.",
+    "Velthryn Strategic Investments",
+] * 3
+
+
+def _race(factory: sessionmaker[Session], names: list[str], entity_type: str) -> list[dict]:
+    """Run one resolve per thread, all released at the same instant."""
+    start = threading.Barrier(len(names))
+    results: list[dict | BaseException] = [None] * len(names)
+
+    def run(index: int) -> None:
+        try:
+            start.wait(timeout=30)
+            results[index] = resolve_or_create_entity(
+                factory,
+                entity_type=entity_type,
+                name=names[index],
+                kind="legal_entity",
+                identifiers={},
+                provenance=PROVENANCE,
+            )
+        except BaseException as error:  # noqa: BLE001 - re-raised below with context
+            results[index] = error
+
+    threads = [threading.Thread(target=run, args=(index,)) for index in range(len(names))]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+    failures = [item for item in results if isinstance(item, BaseException)]
+    if failures:
+        raise failures[0]
+    return results
+
+
+def test_twelve_documents_naming_one_new_entity_create_one_row(
+    factory: sessionmaker[Session],
+) -> None:
+    results = _race(factory, VARIANTS, "client")
+
+    with factory() as session:
+        assert session.scalar(select(func.count()).select_from(Client)) == 1
+        duplicates = session.execute(
+            select(Client.normalized_name, func.count())
+            .group_by(Client.normalized_name)
+            .having(func.count() > 1)
+        ).all()
+        assert duplicates == []
+    assert len({item["id"] for item in results}) == 1
+    assert sum(1 for item in results if item["created"]) == 1
+
+
+def test_racing_creations_of_different_entities_all_land(
+    factory: sessionmaker[Session],
+) -> None:
+    """The lock is per name, not global: unrelated entities must not serialize away."""
+    names = [f"Harrowgate Ventures {index}" for index in range(8)]
+    results = _race(factory, names, "party")
+
+    with factory() as session:
+        assert session.scalar(select(func.count()).select_from(Party)) == 8
+    assert len({item["id"] for item in results}) == 8
+
+
+def test_the_constraint_refuses_a_twin_even_without_the_lock(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    """The schema, not the code path, is what makes a duplicate impossible."""
+    resolve_or_create_entity(
+        factory,
+        entity_type="client",
+        name="Kensington Bank AG",
+        kind="legal_entity",
+        identifiers={},
+        provenance=PROVENANCE,
+    )
+    session.add(Client(name="kensington bank"))
+    with pytest.raises(IntegrityError):
+        session.flush()
+    session.rollback()
+
+
+def test_a_creator_that_loses_the_insert_reads_the_winner(
+    factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The recovery path itself, forced: with linking disabled every call tries to
+    insert, and the second one has to come back with the first one's id rather than
+    raise."""
+    monkeypatch.setattr(
+        matter_search,
+        "link_decision",
+        lambda *args, **kwargs: (None, "no_confident_candidate", []),
+    )
+    first = resolve_or_create_entity(
+        factory,
+        entity_type="party",
+        name="Harrowgate Ventures",
+        kind="legal_entity",
+        identifiers={},
+        provenance=PROVENANCE,
+    )
+    second = resolve_or_create_entity(
+        factory,
+        entity_type="party",
+        name="Harrowgate Ventures Ltd",
+        kind="legal_entity",
+        identifiers={},
+        provenance=PROVENANCE,
+    )
+    assert second["id"] == first["id"]
+    assert second["created"] is False
+    assert second["reason"] == "lost_creation_race"
+    with factory() as session:
+        assert session.scalar(select(func.count()).select_from(Party)) == 1
+        # the loser still contributed what it knew: its spelling is now an alias
+        party = session.get(Party, first["id"])
+        assert party.aliases == []  # "Ltd" is a legal form, so the key is unchanged

--- a/tests/test_entity_names.py
+++ b/tests/test_entity_names.py
@@ -1,0 +1,68 @@
+"""The normalization rule and the comparison built on it, with no database in the way.
+
+These are the cases the old substring predicate could not answer and that a firm's
+estate is full of: the same company written with and without its legal form, with a
+seat appended, with an umlaut spelled two ways, and two companies that merely share a
+word.
+"""
+
+from __future__ import annotations
+
+from knowledge_index.entity_names import name_similarity, name_tokens, normalize_entity_name
+
+
+def _score(left: str, right: str) -> tuple[float, str]:
+    return name_similarity(normalize_entity_name(left), normalize_entity_name(right))
+
+
+def test_legal_form_is_not_part_of_the_name() -> None:
+    assert normalize_entity_name("Nexford Industrial Holdings Inc.") == "nexford industrial holdings"
+    assert normalize_entity_name("Nordwind Energie GmbH") == "nordwind energie"
+    assert normalize_entity_name("Whitfield & Crane LLP") == "whitfield crane"
+    # ... but "Holdings" and "Group" are identity, not form.
+    assert "holdings" in name_tokens(normalize_entity_name("Nexford Holdings"))
+
+
+def test_both_german_spellings_reach_one_form() -> None:
+    assert normalize_entity_name("Müller Verwaltungs AG") == normalize_entity_name(
+        "Mueller Verwaltungs AG"
+    )
+    assert normalize_entity_name("Groß & Partner") == normalize_entity_name("Gross and Partner")
+
+
+def test_the_two_directions_the_substring_predicate_missed() -> None:
+    # "%query%" against the stored name could only ever match one of these.
+    short_first, component = _score("Verimark Group", "Verimark Hospitality Group Inc.")
+    long_first, _ = _score("Verimark Hospitality Group Inc.", "Verimark Group")
+    assert short_first == long_first
+    assert component == "token_containment"
+    assert short_first >= 0.80
+
+    score, component = _score("Nexford", "Nexford Industrial Holdings Inc.")
+    assert component == "token_containment"
+    assert score >= 0.80
+
+
+def test_one_shared_token_scores_below_three() -> None:
+    one, _ = _score("Meridian", "Meridian Health Partners Inc.")
+    three, _ = _score("Meridian Health Partners", "Meridian Health Partners Inc.")
+    assert one < three
+
+
+def test_a_shared_word_is_not_a_match() -> None:
+    score, _ = _score("Meridian Capital Partners LP", "Meridian Health Partners Inc.")
+    assert score < 0.80
+
+
+def test_a_typo_is_recognized_without_a_shared_token() -> None:
+    score, component = _score("Verimarc Hospitality Group", "Verimark Hospitality Group Inc.")
+    assert component in ("characters", "token_overlap")
+    assert score >= 0.80
+
+
+def test_unrelated_names_score_nothing() -> None:
+    assert _score("Nordwind Energie", "Kensington Bank") == (0.0, "")
+
+
+def test_a_name_that_is_only_a_legal_form_normalizes_to_nothing() -> None:
+    assert normalize_entity_name("GmbH & Co. KG") == ""

--- a/tests/test_entity_names.py
+++ b/tests/test_entity_names.py
@@ -64,5 +64,18 @@ def test_unrelated_names_score_nothing() -> None:
     assert _score("Nordwind Energie", "Kensington Bank") == (0.0, "")
 
 
-def test_a_name_that_is_only_a_legal_form_normalizes_to_nothing() -> None:
-    assert normalize_entity_name("GmbH & Co. KG") == ""
+def test_a_name_that_is_only_a_legal_form_keeps_it() -> None:
+    """Stripping a name down to nothing would key every such mention identically, and
+    under the uniqueness constraint that merges unrelated companies rather than merely
+    failing to tell them apart."""
+    assert normalize_entity_name("GmbH & Co. KG") == "gmbh and co kg"
+    assert normalize_entity_name("The Company") == "the company"
+    assert normalize_entity_name("GmbH & Co. KG") != normalize_entity_name("The Company")
+    # Only when there is nothing else. A real name still sheds its form.
+    assert normalize_entity_name("Nordwind Energie GmbH & Co. KG") == "nordwind energie"
+
+
+def test_nothing_in_makes_nothing_out() -> None:
+    assert normalize_entity_name("") == ""
+    assert normalize_entity_name(None) == ""
+    assert normalize_entity_name("   ") == ""

--- a/tests/test_party_resolution.py
+++ b/tests/test_party_resolution.py
@@ -1,14 +1,18 @@
-"""O5 party/client resolution (_resolve_document_parties): the search-then-
-link-or-create writes materialize the firm-wide entity layer, and the same name
-across different matters deliberately stays distinct (the entity-collision case
-the corpus plants with three different "Meridian" companies).
+"""O5 party/client resolution (_resolve_document_parties): what the search-then-
+link-or-create writes materialize, and that one real-world entity ends up as one row
+however many matters and spellings it arrives under.
+
+The corpus this replaces was measured with 1,212 client rows for 46 real clients,
+1,076 of them touching exactly one matter. Cross-matter identity is therefore the
+default here, not a judgement the agent may decline.
 """
 
 from __future__ import annotations
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
+from knowledge_index.config import AppConfig
 from knowledge_index.db.models import (
     Client,
     Document,
@@ -23,34 +27,52 @@ from knowledge_index.pipeline.extraction import ExtractedParty, TypedIdentifier
 from knowledge_index.pipeline.runner import _resolve_document_parties
 
 
-def _matter(session: Session, mid: str, ref: str) -> None:
-    session.add(Matter(id=mid, title=f"Matter {ref}", reference_numbers=[ref]))
-    session.flush()
+def _matter(session: Session, mid: str, ref: str, *, imported: bool = False) -> None:
+    session.add(
+        Matter(id=mid, title=f"Matter {ref}", reference_numbers=[ref], imported=imported)
+    )
+    session.commit()
 
 
 def _doc(session: Session, did: str, matter_id: str) -> Document:
     session.add(Document(id=did, matter_id=matter_id, title="Doc"))
-    session.flush()
+    session.commit()
     return session.get(Document, did)
 
 
-def _resolve(session: Session, document: Document, parties: list[ExtractedParty]) -> list[dict]:
+def _resolve(
+    session: Session,
+    factory: sessionmaker[Session],
+    document: Document,
+    parties: list[ExtractedParty],
+    *,
+    config: AppConfig | None = None,
+) -> list[dict]:
     payload = _resolve_document_parties(
-        session, document, parties, model="test-model", evidence="ev-1"
+        session,
+        document,
+        parties,
+        model="test-model",
+        evidence="ev-1",
+        session_factory=factory,
+        config=config or AppConfig(),
     )
-    session.flush()
+    session.commit()
     return payload
 
 
-def _party_count(session: Session, name: str) -> int:
-    return session.scalar(select(func.count()).select_from(Party).where(Party.name == name))
+def _count(session: Session, model, name: str) -> int:
+    return session.scalar(select(func.count()).select_from(model).where(model.name == name))
 
 
-def test_creates_client_and_party_with_links_and_identifiers(session: Session) -> None:
+def test_creates_client_and_party_with_links_and_identifiers(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
     _matter(session, "m1", "REF-1")
     doc = _doc(session, "d1", "m1")
     payload = _resolve(
         session,
+        factory,
         doc,
         [
             ExtractedParty(name="Kensington Bank", role="client"),
@@ -82,41 +104,153 @@ def test_creates_client_and_party_with_links_and_identifiers(session: Session) -
         is not None
     )
 
-    # payload carries each mention's resolved entity
+    # payload carries each mention's resolved entity and how it got there
     assert {row["entity_type"] for row in payload} == {"client", "party"}
+    assert {row["resolution"] for row in payload} == {"no_confident_candidate"}
 
-    # the loop closes: search_entities (resolve_entity) now finds what we created
+    # the loop closes: entity resolution now finds what we created
     assert any(hit["id"] == party.id for hit in resolve_entity(session, "Meridian"))
 
 
-def test_same_name_across_matters_stays_distinct(session: Session) -> None:
-    # Three matters, three different "Meridian" entities, each created fresh
-    # (existing_id=None). The deliberate name collision must NOT merge them.
-    ids: list[str] = []
-    for i in (1, 2, 3):
-        _matter(session, f"m{i}", f"REF-{i}")
-        doc = _doc(session, f"d{i}", f"m{i}")
-        payload = _resolve(session, doc, [ExtractedParty(name="Meridian", role="opposing_party")])
+def test_one_client_across_many_matters_is_one_row(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    """The shape a firm actually has: a client with five matters, not five clients."""
+    ids = []
+    for index in (1, 2, 3, 4, 5):
+        _matter(session, f"m{index}", f"REF-{index}")
+        payload = _resolve(
+            session,
+            factory,
+            _doc(session, f"d{index}", f"m{index}"),
+            [ExtractedParty(name="Kensington Bank AG", role="client")],
+        )
         ids.append(payload[0]["party_id"])
 
-    assert len(set(ids)) == 3
-    assert _party_count(session, "Meridian") == 3
+    assert len(set(ids)) == 1
+    assert session.scalar(select(func.count()).select_from(Client)) == 1
+    assert (
+        len(
+            session.scalars(
+                select(MatterClient.matter_id).where(MatterClient.client_id == ids[0])
+            ).all()
+        )
+        == 5
+    )
 
 
-def test_existing_id_links_instead_of_creating(session: Session) -> None:
+def test_name_variants_converge_and_are_recorded_as_aliases(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
     _matter(session, "m1", "REF-1")
     _matter(session, "m2", "REF-2")
     first = _resolve(
-        session, _doc(session, "d1", "m1"), [ExtractedParty(name="Meridian", role="opposing_party")]
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [ExtractedParty(name="Nordwind Energie GmbH", role="opposing_party")],
+    )
+    second = _resolve(
+        session,
+        factory,
+        _doc(session, "d2", "m2"),
+        [ExtractedParty(name="Nordwind Energie", role="opposing_party")],
+    )
+    assert second[0]["party_id"] == first[0]["party_id"]
+    assert session.scalar(select(func.count()).select_from(Party)) == 1
+
+    # Same identity, different surface form → the second spelling is now searchable.
+    party = session.get(Party, first[0]["party_id"])
+    session.refresh(party)
+    assert party.aliases == []  # "Nordwind Energie" normalizes to the stored key itself
+    third = _resolve(
+        session,
+        factory,
+        _doc(session, "d3", "m2"),
+        [ExtractedParty(name="Nordwind Energie GmbH, Hamburg", role="opposing_party")],
+    )
+    assert third[0]["party_id"] == first[0]["party_id"]
+    session.refresh(party)
+    assert "Nordwind Energie GmbH, Hamburg" in party.aliases
+    assert "nordwind energie hamburg" in party.normalized_aliases
+
+
+def test_existing_id_links_instead_of_creating(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1")
+    _matter(session, "m2", "REF-2")
+    first = _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [ExtractedParty(name="Meridian", role="opposing_party")],
     )
     party_id = first[0]["party_id"]
 
-    # A second document links to the SAME entity by id (the agent recognized it).
     second = _resolve(
         session,
+        factory,
         _doc(session, "d2", "m2"),
         [ExtractedParty(name="Meridian", role="opposing_party", existing_id=party_id)],
     )
     assert second[0]["party_id"] == party_id
-    assert _party_count(session, "Meridian") == 1
+    assert _count(session, Party, "Meridian") == 1
     assert session.get(MatterParty, ("m2", party_id, "opposing_party")) is not None
+
+
+def test_one_entity_that_is_client_here_and_counterparty_there(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    """Clients and parties are separate tables, so the pair has to be recognizable
+    as one entity rather than as two unrelated ones."""
+    _matter(session, "m1", "REF-1")
+    _matter(session, "m2", "REF-2")
+    _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [
+            ExtractedParty(
+                name="Kensington Bank",
+                role="opposing_party",
+                identifiers=[TypedIdentifier(scheme="lei", value="LEI-KEN")],
+            )
+        ],
+    )
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d2", "m2"),
+        [ExtractedParty(name="Kensington Bank", role="client")],
+    )
+    client = session.get(Client, payload[0]["party_id"])
+    assert client is not None
+    assert client.normalized_name == "kensington bank"
+    # the identifier travelled with the identity
+    assert session.scalar(
+        select(EntityIdentifier).where(
+            EntityIdentifier.entity_type == "client",
+            EntityIdentifier.entity_id == client.id,
+            EntityIdentifier.value == "LEI-KEN",
+        )
+    )
+    assert session.scalar(select(func.count()).select_from(Client)) == 1
+    assert session.scalar(select(func.count()).select_from(Party)) == 1
+
+
+def test_a_document_naming_one_party_twice_writes_one_link(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1")
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [
+            ExtractedParty(name="Kensington Bank AG", role="client"),
+            ExtractedParty(name="Kensington Bank", role="client"),
+        ],
+    )
+    assert payload[0]["party_id"] == payload[1]["party_id"]
+    assert session.scalar(select(func.count()).select_from(MatterClient)) == 1

--- a/tests/test_party_resolution_guard.py
+++ b/tests/test_party_resolution_guard.py
@@ -1,41 +1,88 @@
-"""Entity-resolution forcing (2026-08-01 run audit): a CREATE is only accepted
-when the agent actually searched for the party, and a same-matter verbatim name
-reuses the known entity instead of minting a twin — while same-name entities in
-different matters stay distinct (the deliberate Meridian collision case).
+"""The resolution rule, stated as tests: what links automatically, what is proven
+distinct, what escalates to the agent — and which role claims are refused.
+
+Written against the 9,288-document run this replaces: 1,212 client rows for 46 real
+clients, 985 distinct names carrying role=client including individuals,
+counterparties, and the firm itself 16 times.
 """
 
 from __future__ import annotations
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
-from knowledge_index.db.models import Client, Document, Matter, MatterParty, Party
-from knowledge_index.pipeline.extraction import ExtractedParty
-from knowledge_index.pipeline.matter_search import entity_search_covered
+from knowledge_index.config import AppConfig, FirmConfig
+from knowledge_index.db.models import (
+    Client,
+    Document,
+    Matter,
+    MatterClient,
+    MatterParty,
+    Party,
+)
+from knowledge_index.pipeline.extraction import ExtractedParty, TypedIdentifier
+from knowledge_index.pipeline.matter_search import (
+    entity_candidates,
+    entity_search_covered,
+    link_decision,
+    resolve_or_create_entity,
+)
 from knowledge_index.pipeline.runner import _resolve_document_parties
 
+PROVENANCE = {"method": "inferred", "model": "test-model", "evidence": ["ev-1"]}
 
-def _matter(session: Session, mid: str, ref: str) -> None:
-    session.add(Matter(id=mid, title=f"Matter {ref}", reference_numbers=[ref]))
-    session.flush()
+
+def _matter(session: Session, mid: str, ref: str, *, imported: bool = False) -> None:
+    session.add(
+        Matter(id=mid, title=f"Matter {ref}", reference_numbers=[ref], imported=imported)
+    )
+    session.commit()
 
 
 def _doc(session: Session, did: str, matter_id: str) -> Document:
     session.add(Document(id=did, matter_id=matter_id, title="Doc"))
-    session.flush()
+    session.commit()
     return session.get(Document, did)
 
 
-def _resolve(session: Session, document: Document, parties: list[ExtractedParty]) -> list[dict]:
+def _resolve(
+    session: Session,
+    factory: sessionmaker[Session],
+    document: Document,
+    parties: list[ExtractedParty],
+    *,
+    config: AppConfig | None = None,
+) -> list[dict]:
     payload = _resolve_document_parties(
-        session, document, parties, model="test-model", evidence="ev-1"
+        session,
+        document,
+        parties,
+        model="test-model",
+        evidence="ev-1",
+        session_factory=factory,
+        config=config or AppConfig(),
     )
-    session.flush()
+    session.commit()
     return payload
 
 
-def _party_count(session: Session, name: str) -> int:
-    return session.scalar(select(func.count()).select_from(Party).where(Party.name == name))
+def _create(
+    factory: sessionmaker[Session],
+    name: str,
+    *,
+    entity_type: str = "party",
+    identifiers: dict[str, str] | None = None,
+    matter_id: str | None = None,
+) -> str:
+    return resolve_or_create_entity(
+        factory,
+        entity_type=entity_type,
+        name=name,
+        kind="legal_entity",
+        identifiers=identifiers or {},
+        provenance=PROVENANCE,
+        matter_id=matter_id,
+    )["id"]
 
 
 # --- entity_search_covered: did a query plausibly look for this party? ---
@@ -45,104 +92,215 @@ def test_covered_by_exact_and_suffix_stripped_queries() -> None:
     searched = {"Vantage Prime Bank"}
     assert entity_search_covered("Vantage Prime Bank AG", searched)
     assert entity_search_covered("vantage prime bank", searched)
-    # normalization is symmetric: searching the fuller form covers the shorter name
     assert entity_search_covered("Vantage Prime Bank", {"Vantage Prime Bank AG"})
 
 
 def test_not_covered_by_unrelated_or_absent_queries() -> None:
     assert not entity_search_covered("Meridian Capital Partners LP", set())
-    assert not entity_search_covered(
-        "Meridian Capital Partners LP", {"Vantage Prime Bank"}
-    )
-    # sharing one token is not coverage — each party needs its own search
+    assert not entity_search_covered("Meridian Capital Partners LP", {"Vantage Prime Bank"})
     assert not entity_search_covered(
         "Meridian Health Partners, Inc.", {"Meridian Capital Partners LP"}
     )
 
 
 def test_punctuation_and_case_do_not_defeat_coverage() -> None:
-    assert entity_search_covered(
-        "Whitfield & Crane LLP", {"whitfield  crane"}
+    assert entity_search_covered("Whitfield & Crane LLP", {"whitfield  crane"})
+
+
+# --- the rule ---
+
+
+def test_a_shared_identifier_links_whatever_the_names_say(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    existing = _create(factory, "Velthryn Strategic Investments LP", identifiers={"lei": "LEI-1"})
+    candidates = entity_candidates(
+        session, "Pinnacle Growth Acquisition Corp", identifiers={"lei": "LEI-1"}
     )
+    entity, reason, _ = link_decision(
+        session, candidates, entity_type="party", matter_id=None, sibling_entity_ids=set()
+    )
+    assert reason == "shared_identifier"
+    assert entity is not None and entity.entity_id == existing
 
 
-# --- same-matter verbatim-name net in _resolve_document_parties ---
+def test_an_identical_normalized_name_links_across_matters(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    existing = _create(factory, "Kensington Bank AG")
+    candidates = entity_candidates(session, "kensington bank")
+    entity, reason, _ = link_decision(
+        session, candidates, entity_type="party", matter_id=None, sibling_entity_ids=set()
+    )
+    assert reason == "normalized_name"
+    assert entity is not None and entity.entity_id == existing
 
 
-def test_same_matter_same_name_reuses_entity(session: Session) -> None:
+def test_a_conflicting_register_number_proves_two_companies(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    first = _create(factory, "Meridian Capital", identifiers={"de_hrb": "HRB 111"})
+    second = _create(factory, "Meridian Capital", identifiers={"de_hrb": "HRB 222"})
+    assert first != second
+    assert session.scalar(select(func.count()).select_from(Party)) == 2
+    # The split is recorded on the row, not hidden in a comment.
+    rows = session.scalars(select(Party).order_by(Party.identity_discriminator)).all()
+    assert [row.identity_discriminator for row in rows] == ["", "de_hrb:HRB 222"]
+    # ... and the third mention of the second company links by its identifier.
+    assert _create(factory, "Meridian Capital", identifiers={"de_hrb": "HRB 222"}) == second
+
+
+def test_a_containment_match_alone_does_not_link(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _create(factory, "Verimark Hospitality Group Inc.")
+    candidates = entity_candidates(session, "Verimark Group")
+    assert [item.verdict for item in candidates] == ["likely"]
+    entity, reason, _ = link_decision(
+        session, candidates, entity_type="party", matter_id=None, sibling_entity_ids=set()
+    )
+    assert entity is None
+    assert reason == "no_confident_candidate"
+
+
+def test_a_containment_match_links_when_the_matter_corroborates(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
     _matter(session, "m1", "REF-1")
-    first = _resolve(
-        session, _doc(session, "d1", "m1"), [ExtractedParty(name="Meridian", role="opposing_party")]
+    known = _create(factory, "Verimark Hospitality Group Inc.", matter_id="m1")
+    session.add(MatterParty(matter_id="m1", party_id=known, role="opposing_party"))
+    session.commit()
+
+    candidates = entity_candidates(session, "Verimark Group")
+    entity, reason, corroboration = link_decision(
+        session, candidates, entity_type="party", matter_id="m1", sibling_entity_ids=set()
     )
-    # The agent "forgot" and decided create again for the identical name.
-    second = _resolve(
-        session, _doc(session, "d2", "m1"), [ExtractedParty(name="Meridian", role="opposing_party")]
-    )
-    assert second[0]["party_id"] == first[0]["party_id"]
-    assert _party_count(session, "Meridian") == 1
+    assert entity is not None and entity.entity_id == known
+    assert reason == "name_and_corroboration"
+    assert corroboration == ["already_on_this_matter"]
 
 
-def test_net_is_case_insensitive_and_spans_roles(session: Session) -> None:
+def test_creating_alongside_a_candidate_is_recorded_on_the_row(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    """'Created a second entity for a name the estate already knows' has to be
+    countable, not merely regrettable."""
+    _create(factory, "Verimark Hospitality Group Inc.")
+    created = _create(factory, "Verimark Group")
+    row = session.get(Party, created)
+    resolution = (row.provenance or {})["resolution"]
+    assert resolution["decision"] == "created"
+    assert [item["name"] for item in resolution["shadowed_candidates"]] == [
+        "Verimark Hospitality Group Inc."
+    ]
+    counted = session.scalar(
+        select(func.count())
+        .select_from(Party)
+        .where(func.jsonb_array_length(Party.provenance["resolution"]["shadowed_candidates"]) > 0)
+    )
+    assert counted == 1
+
+
+# --- role assignment ---
+
+
+def test_the_firm_is_never_its_own_client(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    config = AppConfig(firm=FirmConfig(name="Whitfield & Crane LLP", aliases=["Whitfield Crane"]))
     _matter(session, "m1", "REF-1")
-    first = _resolve(
-        session, _doc(session, "d1", "m1"), [ExtractedParty(name="Meridian Capital", role="advisor")]
-    )
-    second = _resolve(
+    payload = _resolve(
         session,
-        _doc(session, "d2", "m1"),
-        [ExtractedParty(name="  MERIDIAN CAPITAL ", role="opposing_party")],
-    )
-    assert second[0]["party_id"] == first[0]["party_id"]
-    # the second role still gets its own matter link on the shared entity
-    assert session.get(MatterParty, ("m1", first[0]["party_id"], "advisor")) is not None
-    assert session.get(MatterParty, ("m1", first[0]["party_id"], "opposing_party")) is not None
-
-
-def test_net_applies_to_clients_too(session: Session) -> None:
-    _matter(session, "m1", "REF-1")
-    first = _resolve(
-        session, _doc(session, "d1", "m1"), [ExtractedParty(name="Kensington Bank", role="client")]
-    )
-    second = _resolve(
-        session, _doc(session, "d2", "m1"), [ExtractedParty(name="Kensington Bank", role="client")]
-    )
-    assert second[0]["party_id"] == first[0]["party_id"]
-    assert (
-        session.scalar(
-            select(func.count()).select_from(Client).where(Client.name == "Kensington Bank")
-        )
-        == 1
-    )
-
-
-def test_cross_matter_same_name_still_stays_distinct(session: Session) -> None:
-    # The net must NOT merge across matters: different companies share names.
-    ids = []
-    for i in (1, 2):
-        _matter(session, f"m{i}", f"REF-{i}")
-        payload = _resolve(
-            session,
-            _doc(session, f"d{i}", f"m{i}"),
-            [ExtractedParty(name="Meridian", role="opposing_party")],
-        )
-        ids.append(payload[0]["party_id"])
-    assert len(set(ids)) == 2
-    assert _party_count(session, "Meridian") == 2
-
-
-def test_variant_names_in_one_matter_stay_distinct(session: Session) -> None:
-    # Verbatim-only matching: "Inc." vs "LLC" variants are NOT collapsed by the
-    # net — that judgment stays with the agent via search_entities.
-    _matter(session, "m1", "REF-1")
-    _resolve(
-        session,
+        factory,
         _doc(session, "d1", "m1"),
-        [ExtractedParty(name="Meridian Health Partners, Inc.", role="advisor")],
+        [
+            ExtractedParty(name="Whitfield & Crane LLP", role="client"),
+            ExtractedParty(name="Kensington Bank", role="client"),
+        ],
+        config=config,
     )
+    firm, client = payload
+    assert firm["role"] == "advisor"
+    assert firm["claimed_role"] == "client"
+    assert firm["role_refused_because"] == "own_firm"
+    assert firm["entity_type"] == "party"
+    assert client["role"] == "client"
+    assert session.scalars(select(Client.name)).all() == ["Kensington Bank"]
+
+
+def test_the_firm_filter_is_inert_until_the_firm_is_named(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1")
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [ExtractedParty(name="Whitfield & Crane LLP", role="client")],
+    )
+    assert payload[0]["role"] == "client"
+
+
+def test_an_existing_party_on_the_matter_cannot_become_its_client(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1")
     _resolve(
         session,
-        _doc(session, "d2", "m1"),
-        [ExtractedParty(name="Meridian Health Partners, LLC", role="advisor")],
+        factory,
+        _doc(session, "d1", "m1"),
+        [ExtractedParty(name="Meridian Capital", role="opposing_party")],
     )
-    assert _party_count(session, "Meridian Health Partners, Inc.") == 1
-    assert _party_count(session, "Meridian Health Partners, LLC") == 1
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d2", "m1"),
+        [ExtractedParty(name="Meridian Capital", role="client")],
+    )
+    assert payload[0]["role"] == "opposing_party"
+    assert payload[0]["role_refused_because"] == "already_a_party_on_this_matter"
+    assert session.scalar(select(func.count()).select_from(Client)) == 0
+
+
+def test_an_imported_matters_client_outranks_the_document(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1", imported=True)
+    authoritative = _create(factory, "Kensington Bank AG", entity_type="client")
+    session.add(MatterClient(matter_id="m1", client_id=authoritative))
+    session.commit()
+
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [
+            ExtractedParty(name="Derek Caldwell", role="client", kind="natural_person"),
+            ExtractedParty(name="Kensington Bank", role="client"),
+        ],
+    )
+    person, client = payload
+    assert person["role"] == "other"
+    assert person["role_refused_because"] == "matter_client_is_authoritative"
+    assert client["role"] == "client" and client["party_id"] == authoritative
+    assert session.scalar(select(func.count()).select_from(MatterClient)) == 1
+
+
+def test_typed_identifiers_are_promoted_for_the_role_the_mention_got(
+    session: Session, factory: sessionmaker[Session]
+) -> None:
+    _matter(session, "m1", "REF-1")
+    payload = _resolve(
+        session,
+        factory,
+        _doc(session, "d1", "m1"),
+        [
+            ExtractedParty(
+                name="Nordwind Energie GmbH",
+                role="opposing_party",
+                identifiers=[TypedIdentifier(scheme="de_hrb", value="HRB 45678")],
+            )
+        ],
+    )
+    party = session.get(Party, payload[0]["party_id"])
+    assert party.identifiers == {"de_hrb": "HRB 45678"}


### PR DESCRIPTION
Measured on an index of 9,288 documents across 266 matters whose ground truth is **46 clients**, the `clients` table held **1,212 rows**. Normalization collapses the 985 distinct names to only 942, so this was never spelling variance. **1,076 of the 1,212 touched exactly one matter**, where a real client averages 5.8. The firm itself was filed as a client 16 times. **973 creations reused a normalized name the estate already held, 293 of them within 60 seconds** of the row they duplicated.

The insertion agent was not at fault. Its recovered reasoning reads *"No match for VELTHRYN STRATEGIC INVESTMENTS, LP. Let's search for PINNACLE GROWTH ACQUISITION CORP."* It searched, was told nothing existed, and created. The tools it was given were the problem:

- the lexical leg was `Party.name ILIKE '%query%'`, which cannot match "Nexford" against a stored "Nexford Industrial Holdings Inc." in **either** direction — while a normalizer sat unused in the same file behind a validator;
- the primary leg was semantic over already-**indexed** chunks, and `index` is the last stage in `PIPELINE_STAGE_ORDER`, so during a bulk run it is empty exactly when extraction needs it (extraction stood at 9,122 documents against index's 7,033, near-empty for the first several thousand);
- creation raced itself: the only guard was matter-scoped, with no uniqueness constraint and no lock;
- cross-matter resolution was off by design, which at scale means one client row per matter — and "show me everything for this client" is the question the product exists to answer.

## What links automatically, and what escalates

Whether two names are one entity is now decided by rule (`matter_search.link_decision`), applied to every mention regardless of what the agent submitted. It is one function so it can be read, argued with, and tested. A mention links when:

1. **it shares a typed identifier** with a known entity — proof, and it outranks every name signal;
2. **the normalized names are identical**, or the mention's name is already on that entity's alias ledger, and no register identifier contradicts it. This is the default path *across matters*, not a judgement the agent may decline;
3. **one name contains the other token-for-token AND something beyond the name agrees**: the entity is already on this matter, it shares a matter with another party named on this document, or it acts on another matter for this matter's client.

Everything weaker **escalates**: the candidates go back to the agent with their evidence (matching and conflicting identifiers, matter count, sampled matter refs, whether it is already on this matter, and a `match.verdict`) and it decides. Creating alongside a known candidate stays allowed — different companies genuinely share names — but it is recorded on the new row's `provenance.resolution.shadowed_candidates`, so "created a second entity for a name the estate already knew" is a countable event rather than a suspicion.

Identity is a column now, not a search result. `normalized_name` is written by one rule (`knowledge_index.entity_names`) shared by the persistence layer, the resolver and the constraint; names compare as **token sets**, so short and long forms find each other in both directions; every surface form that resolves is kept on an alias ledger and matches exactly from then on. **No candidate leg depends on the `index` stage.**

## How the race is made impossible

Three independent guards, tested one at a time in `tests/test_entity_creation_race.py`:

1. **A short committed transaction.** Each entity is resolved-or-created in its own session and committed before the call returns, so a sibling document extracting the same party in parallel sees it immediately instead of minutes later when the stage transaction lands. That alone removes the 293-in-60-seconds bulk.
2. **An advisory transaction lock on the normalized name**, making search-then-create atomic per name without serializing unrelated entities.
3. **A unique constraint on `(normalized_name, identity_discriminator)`.** Whatever reaches an insert anyway — a lock-key collision, a future caller that forgets — loses and re-reads the winner. This is the guard that does not depend on anyone remembering to use the code path.

`identity_discriminator` is empty for nearly everything. It is non-empty only when the estate already holds this normalized name **and** the mention carries a register identifier that contradicts it — the one case where two rows for one name are the truth rather than the bug, and the only thing the constraint admits as a second row.

Role assignment stops being a prompt instruction (`runner._effective_party_role`): the firm is never its own client (`firm.name`, inert until set), an entity already carrying a role on a matter keeps it, and an imported matter's practice-management client outranks a document-level claim. Each refusal keeps the model's claim next to it (`claimed_role`, `role_refused_because`) rather than quietly overwriting it.

## What the migration does to existing rows

`d9a41f6c73b2` adds `normalized_name`, `identity_discriminator` and `normalized_aliases` to `clients` and `parties`, a trigram GIN index on the key, a GIN index on the alias ledger, and the unique constraint.

- **Backfill runs the Python rule itself**, batched, over the rows being migrated. It does not compute the key in SQL — see the first review note below.
- **It refuses to migrate an estate that still holds duplicates**, naming them: choosing which of two entities survives is a merge, and a migration must never perform one. Repair first, then migrate.
- A fresh estate migrates to an empty table and nothing is backfilled at all.

Verified end to end against a scratch database: upgrade from `c4e18b9d2f07` with seeded pre-migration rows, every backfilled key byte-identical to `normalize_entity_name`, indexes and constraint present, the duplicate refusal firing with the colliding key named, and `downgrade -1` reversing cleanly. **Not run against any deployment.**

## Three things I changed in the previous design, and why

These are called out rather than buried, because each is a judgement someone may want to reverse.

**1. The migration's backfill was written in SQL, and it drifted from the rule on every name I tried.** `lower(unaccent(...))` has no legal-form list, so it produced `whitfield crane llp`, `nordwind energie gmbh`, `mueller verwaltungs ag` where the application produces `whitfield crane`, `nordwind energie`, `mueller verwaltungs` — 5 of 5 seeded names disagreed. The original header acknowledged the approximation and argued the wrongness was the data repair's problem. I do not think it is: every migrated row would carry a key the resolver never computes again, so the first document naming that company creates the twin this PR exists to prevent. It is also precisely the Python-versus-SQL drift `entity_names.py`'s own header warns about, performed by the migration. The migration now imports the rule. **The tradeoff to weigh:** a migration that imports live application code will compute with a *future* version of that rule if it is ever replayed after the rule changes. I judged byte-identity with the current application to be the property that matters here; pinning a frozen copy into the migration is the alternative.

**2. A name whose every token is a legal form normalized to the empty string.** "GmbH & Co. KG", "The Company", "S.A." and "Ltd" all stripped to `""`. Under a uniqueness constraint an empty key is not a missed match, it is a **merge** — I confirmed against the database that two unrelated parties named "GmbH & Co. KG" and "The Company" collapsed into a single row. Stripping now only happens when something survives it; the legal form is noise *around* an identity, not when it is all the identity there is. This deletes the previous `test_a_name_that_is_only_a_legal_form_normalizes_to_nothing`, which encoded the behaviour, and replaces it with one asserting the two do not collide, plus a resolver-level test.

**3. The mirror path was the one insert that did not degrade to a re-select.** When a company is the client on one matter and a counterparty on another it needs a row in each table, and `_mirror_entity` creates the counterpart. But the advisory lock is keyed on the *mention's* normalized name, and mentions reaching one entity through its alias ledger hold *different* keys — so two resolvers can be there for one company at once without ever contending, and the loser raised an `IntegrityError` that failed its document. It now loses inside a savepoint and reads the winner, which is what the surrounding docstring already promised. `test_the_counterpart_row_is_raced_for_too` drives three threads through it; instrumented, the recovery branch fired on every one of six runs.

## Also worth a second opinion

- **`firm.name` does nothing until an operator sets it.** That is deliberate — an appliance that has not been told whose it is must not guess, and a wrong name here would demote a real client — but it means the "firm filed as its own client 16 times" failure keeps happening on any deployment that never sets it. It is now documented in the pipeline configuration table so it is at least findable; whether it should be part of first-run setup is a product call.
- **Connection-pool pressure.** Each mention now opens a second, short-lived session while the stage's session is still open, so peak pool demand per worker roughly doubles during `extract_metadata`. Nothing in the test suite pushed it, but it is the kind of thing that shows up at real insertion concurrency.
- **The alias ledger is last-write-wins.** Two resolvers appending different surface forms to one entity concurrently can lose one of them. Aliases are an accelerator, not identity — the next document re-derives the match fuzzily and re-records it — so I left it, but it is a lost update.
- **`_effective_party_role` matches the incumbent on `normalized_name` only**, not on the alias ledger. A party recorded under a variant spelling can therefore still be claimed as the matter's client. Narrow, and it fails toward the safer outcome.

## Tests

`tests/test_entity_names.py` (the rule, no database), `tests/test_entity_creation_race.py` (real threads, real database, row counts afterwards), and reworked `tests/test_party_resolution.py` / `tests/test_party_resolution_guard.py` (the rule stated as tests: what links, what is proven distinct, what escalates, which role claims are refused).

**Local run: 812 passed, 9 deselected.** Excluded locally are `test_backup.py` / `test_backup_roundtrip.py`, which fail on this machine with `pg_dump: aborting because of server version mismatch` — a local client at 14 against a server at 16, unrelated to this change and green in CI, which ships the matching client. With them included the run is 30 failures, all downstream of that one cause. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNxkZAxBpHjMpyVQC8yx3
