### PR TITLE
demo: openers for the corpus it now holds, and the filters to answer them

### DIFF
--- a/demo/src/app/api/chat/route.ts
+++ b/demo/src/app/api/chat/route.ts
@@ -31,12 +31,14 @@ const SYSTEM_PROMPT = `You are the LegalMemory demo assistant. You answer questi
 
 Every fact you state about a document must come from a tool call in this conversation. You have:
 
-- search_semantic — hybrid semantic and lexical search over document contents. Takes matter_id, doc_type and only_final filters. Ask for 5-8 results, not 20.
+- search_semantic — hybrid semantic and lexical search over document contents. Takes matter_id, doc_type, only_final, practice_area, practice_group, firm_person and lifecycle filters. Ask for 5-8 results, not 20.
 - search_filter — the same estate by exact metadata alone, with no query. Use it to enumerate a matter.
 - search_in_document — rank ONE document's own passages against a question and read only what answers it. The first call to make on a document you have identified: it reaches the clause without the pages in front of it, and each hit names the get_document page it sits on.
 - get_document — read that document through, a page of chunks at a time. Continue with page.next_page while has_more is true. A page is a prefix, so an answer that something is NOT in a document can only be given from the end of it.
 - find_related_documents — stored relations for one document: draft-to-final chains, annexes, exhibits, referenced contracts, each with the evidence that established it.
-- list_matters — the firm's matter list. Takes practice_area too.
+- list_matters — the firm's matter list. Filters: practice_area, and also **practice_group**, firm_person and lifecycle. A question phrased the way a lawyer phrases it ("our Banking & Finance matters", "the funds team's") is about the practice GROUP — the group of the partner who owns the matter — not the practice area, which is which body of law applies. Each row says whether that group owns the matter or was only staffed onto it; say which set you are reporting.
+- list_matter_documents — EVERY document in one matter, complete and unpaged. The folder view. Call it before deciding a matter lacks something: a page of search hits is a sample, and a document filed under a title your query did not use is invisible to ranking.
+- list_firm_people — the firm's own lawyers, and the directory behind the practice_group and firm_person filters. Use it to learn what a group is actually called before filtering on it.
 - list_taxonomies — the practice-area, document-type and task-type trees. Use it to turn a practice area's name into the node id that search_filter, search_semantic and list_matters take.
 
 Every list-shaped tool returns \`{results, page}\`, not a bare list. \`page.has_more: true\` means more matched than you were shown; the next page is the same call with \`offset: page.next_offset\`. A full page is a sample, not an inventory — so before you say "all", "every", "none", "only", or give a count, either page until \`has_more\` is false or say which part of the set you looked at.

--- a/demo/src/components/assistant-ui/thread.tsx
+++ b/demo/src/components/assistant-ui/thread.tsx
@@ -190,20 +190,25 @@ const ThreadWelcome: FC = () => <WelcomeHeading />;
 /**
  * Openers, phrased as the questions this appliance is actually good at.
  *
- * Each one exercises a different path: a semantic search over contents, a
- * relation traversal, the matter list, an entity-to-mandate traversal with
- * disambiguation, a cross-matter practice-research synthesis, and the
- * engagement history. Somebody opening the demo cold clicks one of these, and
- * what they get back should be the argument for the product rather than a
- * chat greeting.
+ * These are partner questions, not lookups, and each one is a whole-estate
+ * question with a different shape: scoping a practice group and enumerating a
+ * term of art inside it; a trend that has to be assembled year by year; a sweep
+ * that has to reach every matter before it can say "every"; a comparison across
+ * two buckets that must be defined before they can be counted; and a
+ * distinction between what was signed and what was only ever drafted.
+ *
+ * What makes them the argument for the product is that none can be answered
+ * from one search. Each needs a scope fixed with filters, the scope searched
+ * from several angles, documents actually read, and the answer stated with the
+ * matters behind it — which is the work, and the part a keyword search over a
+ * document store cannot do.
  */
 const STARTERS = [
-  "What pre-money valuation did we nail down for the Novabridge Series B round?",
-  "Which outside firm drafted Luminos's first markup on the deal?",
-  "Who is Carolyn Voss?",
-  "In which mandates is Sarah Castellano involved?",
-  "Have we dealt with Series A financing rounds? What issues surfaced during them?",
-  "Who have we worked with most recently?",
+  "Across our Bankruptcy & Restructuring matters, how often has DIP financing featured — whether we acted for the debtor, the DIP lender, or a creditor responding to one — and which matters were they?",
+  "How has representation and warranty insurance uptake on our M&A deals shifted year over year, and which deals sit behind each year's number?",
+  "I'm running a sanctions-exposure sweep: find every matter where OFAC comes up, and point me to the documents that reference it.",
+  "I'm advising a client negotiating a reverse termination fee. How often have these appeared in our sponsor-backed deals versus our strategic-buyer deals, and what did the triggers look like?",
+  "Give me a by-year breakdown of the Labor & Employment matters carrying an executed clawback provision — and flag separately any that were drafted but never signed.",
 ];
 
 const ThreadSuggestions: FC = () => {

--- a/demo/src/lib/mcp.ts
+++ b/demo/src/lib/mcp.ts
@@ -54,6 +54,25 @@ const searchFilters = {
         "area covers its children. Resolve the id with list_taxonomies first. This is " +
         "how a question about a practice is answered in one call.",
     ),
+  // A practice GROUP is how the firm organises itself — the group of the partner
+  // who owns the matter — and it is what a question phrased the way a lawyer
+  // phrases it ("our Banking & Finance matters") is actually about. The practice
+  // AREA above is which body of law applies. Without this filter that question
+  // has no filtered form, and the model falls back to reading matters one at a
+  // time and stopping when it runs out of room.
+  practice_group: z
+    .string()
+    .optional()
+    .describe(
+      "The firm's own group, by name — 'Banking & Finance', 'Litigation (General)'. " +
+        "Matches every group with someone on the matter; each row then says whether " +
+        "that group owns it or was only staffed onto it. Names come from list_firm_people.",
+    ),
+  firm_person: z.string().optional().describe("One of the firm's own lawyers, by name or id."),
+  lifecycle: z
+    .string()
+    .optional()
+    .describe("Whether the matter happened: executed | closed | terminated | dormant | in_progress."),
   only_final: z
     .boolean()
     .optional()
@@ -124,6 +143,35 @@ export const CHAT_TOOL_SCHEMAS = {
         .string()
         .optional()
         .describe("Ontology node id; matches the whole subtree. From list_taxonomies."),
+      practice_group: z
+        .string()
+        .optional()
+        .describe("The firm's own group by name, e.g. 'Mergers & Acquisitions'."),
+      firm_person: z.string().optional().describe("One of the firm's own lawyers."),
+      lifecycle: z
+        .string()
+        .optional()
+        .describe("executed | closed | terminated | dormant | in_progress."),
+      limit: z.number().int().min(1).max(50).optional(),
+      offset: z.number().int().min(0).optional().describe("Continue from page.next_offset."),
+    }),
+  },
+  // The folder view, complete and unpaged. A question about what a matter does
+  // or does not contain cannot be answered from a page of search hits: a full
+  // page is a sample, and an agreement filed under a title the query did not use
+  // is invisible to ranking. This is how "the matter has no such document"
+  // becomes a claim somebody can stand behind.
+  list_matter_documents: {
+    inputSchema: z.object({
+      matter_id: z.string().describe("From matter_id on any result row."),
+    }),
+  },
+  // The directory behind practice_group and firm_person. A model that has to
+  // guess what a group is called guesses wrong, and a filter that matches
+  // nothing is indistinguishable from a firm that has no such matters.
+  list_firm_people: {
+    inputSchema: z.object({
+      practice_group: z.string().optional().describe("Restrict to one group."),
       limit: z.number().int().min(1).max(50).optional(),
       offset: z.number().int().min(0).optional().describe("Continue from page.next_offset."),
     }),


### PR DESCRIPTION
**The starters were about to break.** Every one of them named an entity from the
corpus this deployment is replacing — a company, a counterparty, two of the
firm's own lawyers. Against the incoming estate they resolve to nothing, so a
cold visitor's first click would have returned an empty answer.

The replacements are partner questions rather than lookups, and none can be
answered from a single search: each needs a scope fixed with filters, that scope
searched from several angles, documents actually read, and the answer stated
with the matters behind it. They cover a practice group enumerated on a term of
art, a year-over-year trend, an estate-wide sweep that has to reach every matter
before it may say "every", a comparison between two buckets that have to be
defined before they can be counted, and the difference between what was executed
and what was only drafted.

**Three of those need tools this surface did not offer**, which is the failure
mode worth naming: a missing tool does not announce itself. The model does the
job the long way, stops when it runs out of room, and returns a partial answer
that reads like a complete one.

* `practice_group`, `firm_person` and `lifecycle` on the search filters and on
  list_matters. A question asked the way a lawyer asks it — "our Banking &
  Finance matters" — is about the group that owns the matter, not the practice
  area, which is which body of law applies. Without the filter that question has
  no filtered form.
* `list_matter_documents`, the complete unpaged folder view. "This matter has no
  such document" cannot be said from a page of search hits: a full page is a
  sample, and an agreement filed under a title the query did not use is
  invisible to ranking.
* `list_firm_people`, the directory behind the other two. A model guessing what
  a group is called guesses wrong, and a filter matching nothing looks exactly
  like a firm with no such matters.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
Paired with the corpus swap on the hosted demo: the incoming estate is a different firm, so the previous starters — which named entities from the outgoing one — would have returned nothing on a cold visitor's first click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)