### PR TITLE
demo: the sign-in door carries the same three links the header does

### DIFF
--- a/demo/src/app/page.tsx
+++ b/demo/src/app/page.tsx
@@ -2,24 +2,11 @@ import { UserButton } from "@clerk/nextjs";
 
 import { principals } from "@/lib/appliance";
 import { authEnabled } from "@/lib/auth";
+import { NAV_LINKS } from "@/lib/nav-links";
 import { McpModal } from "@/components/mcp-modal";
 import { Workspace } from "@/components/workspace";
 
 export const dynamic = "force-dynamic";
-
-/**
- * Everything this demo is not.
- *
- * The demo answers one question well and then a visitor wants the rest: how it
- * works, what it costs them to run, and whether the source is real. Hard-coded
- * rather than configurable — these are the product's own addresses, and a demo
- * running somewhere else still points at them.
- */
-const NAV_LINKS = [
-  { label: "Docs", href: "https://legalmemory.eigenweltlabs.com/docs" },
-  { label: "GitHub", href: "https://github.com/eigenweltlabs/LegalMemory" },
-  { label: "Website", href: "https://eigenweltlabs.com/legalmemory" },
-] as const;
 
 /**
  * The whole application.

--- a/demo/src/components/auth-shell.tsx
+++ b/demo/src/components/auth-shell.tsx
@@ -13,6 +13,8 @@
  */
 import type { ReactNode } from "react";
 
+import { NAV_LINKS } from "@/lib/nav-links";
+
 /**
  * The wordmark, set exactly as the header and the product page set it.
  *
@@ -71,7 +73,26 @@ export function AuthShell({
 
           <div className="mt-6 w-full sm:mt-8">{children}</div>
 
-          <p className="mt-8 text-center font-mono text-[10.5px] tracking-[0.08em] text-white/25 uppercase sm:mt-10">
+          {/* The header shows these only to somebody who signed in, and most
+              visitors never do — the door is where they turn around. The same
+              three links, in the chrome's own mono, below the form rather than
+              beside it: somebody here to sign in should not have to read past
+              them, and somebody about to leave should not have to hunt. */}
+          <nav className="mt-8 flex items-center gap-5 sm:mt-10">
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-[10.5px] tracking-[0.11em] text-white/40 uppercase transition-colors duration-[var(--lm-dur-fast)] hover:text-[var(--lm-orange-hi)]"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+
+          <p className="mt-5 text-center font-mono text-[10.5px] tracking-[0.08em] text-white/25 uppercase">
             Eigenwelt Labs
           </p>
         </div>

--- a/demo/src/lib/nav-links.ts
+++ b/demo/src/lib/nav-links.ts
@@ -1,0 +1,17 @@
+/**
+ * Everything this demo is not.
+ *
+ * The demo answers one question well and then a visitor wants the rest: how it
+ * works, what it costs them to run, and whether the source is real. Hard-coded
+ * rather than configurable — these are the product's own addresses, and a demo
+ * running somewhere else still points at them.
+ *
+ * Shared between the workspace header and the sign-in door, because most
+ * visitors never get past the door: a link that only exists after login is a
+ * link most of them never see.
+ */
+export const NAV_LINKS = [
+  { label: "Docs", href: "https://legalmemory.eigenweltlabs.com/docs" },
+  { label: "GitHub", href: "https://github.com/eigenweltlabs/LegalMemory" },
+  { label: "Website", href: "https://eigenweltlabs.com/legalmemory" },
+] as const;


### PR DESCRIPTION
Docs, GitHub and Website existed only in the workspace header, which only somebody who signed in ever saw — and most visitors stop at the door. The links move to a shared module (`demo/src/lib/nav-links.ts`) and the auth shell renders them under the form, so sign-in and sign-up show them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)