### PR TITLE
Fix the download path: reachable link, and bytes only when they are worth carrying

### DIFF
--- a/demo/src/app/api/downloads/[token]/[filename]/route.ts
+++ b/demo/src/app/api/downloads/[token]/[filename]/route.ts
@@ -1,0 +1,74 @@
+import { applianceUrl, identityHeaders } from "@/lib/appliance";
+
+/**
+ * The appliance's short-lived download link, republished by the demo.
+ *
+ * `download_document` answers three ways at once: the bytes ride back inside the
+ * tool result as a base64 blob, and beside them sit a `download_url` and a
+ * `save_command` curl for a client that would rather fetch the file than decode
+ * it. The blob is the reliable one and the tool description says so. The link is
+ * the older path, and until this route existed it was broken for every client
+ * reaching us through `/mcp`: the appliance is not on the internet, so a URL
+ * naming it directly resolves to nothing outside the container network, and this
+ * app published no `/api/downloads/...` of its own for it to name instead.
+ *
+ * Both halves of that are fixed here. The MCP proxy forwards the origin the
+ * caller actually reached us on, so the appliance mints a link on this host, and
+ * this route serves it — the same capability path, re-based onto the appliance
+ * the way `/api/preview` already does. A client that follows the link or runs the
+ * curl now gets the file, and one that reads the blob is unaffected.
+ *
+ * Only the token and the filename are taken from the request, and they are
+ * re-encoded onto the configured appliance origin rather than used to build a
+ * URL. Nothing a caller sends can point this fetch at another host.
+ *
+ * There is no session check, and that is the design rather than an omission. The
+ * capability token IS the credential: the appliance issues it only to a caller
+ * that was authorized for that document version, binds it to the principals held
+ * at that moment, expires it, re-checks the ACL snapshot on every read, and
+ * revokes it when the grant is gone. A second gate here would buy none of that
+ * and would break the two things the link exists for — a curl from a terminal
+ * and a fetch from an agent, neither of which carries this app's session.
+ */
+
+// A capability token as `secrets.token_urlsafe` writes one, and nothing else.
+const TOKEN = /^[A-Za-z0-9._~-]{16,128}$/;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; filename: string }> },
+) {
+  const { token, filename } = await params;
+  if (!TOKEN.test(token) || !filename) {
+    return Response.json({ error: "download link is invalid or expired" }, { status: 404 });
+  }
+
+  const upstream = `${applianceUrl()}/api/downloads/${encodeURIComponent(token)}/${encodeURIComponent(filename)}`;
+  let blob: Response;
+  try {
+    blob = await fetch(upstream, { headers: identityHeaders(), cache: "no-store" });
+  } catch {
+    return Response.json({ error: "appliance unreachable" }, { status: 502 });
+  }
+
+  if (!blob.ok || !blob.body) {
+    // The appliance distinguishes an invalid or expired link (404) from a
+    // document whose blob has gone (410), and a caller acts differently on
+    // each — ask again, or stop asking. Passing the status through keeps that
+    // difference instead of flattening both to "failed".
+    return Response.json(
+      { error: blob.status === 410 ? "original document is unavailable" : "download link is invalid or expired" },
+      { status: blob.status || 502 },
+    );
+  }
+
+  const headers = new Headers({ "cache-control": "private, no-store", "x-content-type-options": "nosniff" });
+  // The appliance already named the file and its type on the way out; carrying
+  // its own headers is what makes `curl --output` and a browser's Save dialog
+  // land on the original name rather than on the token.
+  for (const key of ["content-type", "content-disposition", "content-length"]) {
+    const value = blob.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  return new Response(blob.body, { headers });
+}

--- a/demo/src/app/api/preview/route.ts
+++ b/demo/src/app/api/preview/route.ts
@@ -23,6 +23,9 @@ export async function GET(request: Request) {
       document_id: documentId,
       version_id: url.searchParams.get("version_id") ?? undefined,
       source_object_id: url.searchParams.get("source_object_id") ?? undefined,
+      // Only the capability path below is used, so the base64 copy of the same
+      // bytes would be built, sent and thrown away on every preview click.
+      inline_blob: false,
     });
 
     const meta = (result.structuredContent ?? {}) as {

--- a/demo/src/app/mcp/[[...path]]/route.ts
+++ b/demo/src/app/mcp/[[...path]]/route.ts
@@ -59,10 +59,20 @@ async function authorize(request: Request): Promise<Response | null> {
 }
 
 async function proxy(request: Request, body: string | null) {
+  // The appliance writes URLs into its own answers — `download_document` hands
+  // back a `download_url` and a `save_command` curl — and it builds them from
+  // the Host of the call it is answering. That is this process, on a container
+  // address no client can reach, so without these two headers every link it
+  // mints through here names a host that does not exist outside the network.
+  // Forwarding the origin the caller actually used points them at
+  // /api/downloads/..., which this app republishes.
+  const origin = new URL(publicOrigin(request));
   const upstream = await fetch(mcpUrl(), {
     method: request.method,
     headers: {
       ...identityHeaders(),
+      "x-forwarded-host": origin.host,
+      "x-forwarded-proto": origin.protocol.replace(/:$/, ""),
       "content-type": request.headers.get("content-type") ?? "application/json",
       // Streamable HTTP negotiates between JSON and SSE on this header, so the
       // client's preference is carried rather than replaced.

--- a/demo/src/middleware.ts
+++ b/demo/src/middleware.ts
@@ -60,6 +60,13 @@ const selfAuthenticating = (pathname: string) =>
   pathname.startsWith("/sign-up") ||
   pathname === "/mcp" ||
   pathname.startsWith("/mcp/") ||
+  // A capability link the appliance minted. The token in the path is the whole
+  // credential — issued only to a caller already authorized for that document
+  // version, bound to the principals held at that moment, short-lived, and
+  // re-checked against the ACL snapshot on every read. The session gate would
+  // add nothing to that and would break what the link is for: a curl from a
+  // terminal and a fetch from an agent, neither of which carries a session.
+  pathname.startsWith("/api/downloads/") ||
   pathname.startsWith("/.well-known/") ||
   // RFC 7591 registration is unauthenticated by design: a client posts here
   // precisely because it has no credentials yet. Behind the session gate it

--- a/docs/src/content/docs/product/external-access.md
+++ b/docs/src/content/docs/product/external-access.md
@@ -58,7 +58,7 @@ tool's name, short title, and tags.
 | `search_semantic` | Hybrid semantic + lexical search over chunks, ACL-filtered before ranking. | `query`, the same metadata filters, `limit` (default 8, capped 100), `offset` (see the ranked-window cap below) |
 | `get_document` | Reads one authorized document version, one page of chunks at a time. | `document_id`, `version_id`, `page` (default 1), `chunks_per_page` (default 12); returns a `page` block with `pages`, `first_chunk`, `last_chunk`, `total_chunks`, `has_more`, `next_page` |
 | `search_in_document` | Ranks one document's own passages against a query, for finding a clause without reading the file. | `document_id`, `query`, `version_id`, `limit` (default 5), `offset`; each result carries the chunk `ordinal` and the `get_document_page` that holds it |
-| `download_document` | Exports the exact original binary via a short-lived download link (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (embeds the base64 blob instead of only linking) |
+| `download_document` | Exports the exact original binary: the bytes in the result, plus a short-lived download link (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (default true; false returns the link alone) |
 | `find_related_documents` | Stored relations plus labeled shared-thread and shared-matter context, with graph-ready edges. | `document_id`, `include_same_matter` (default true), `limit` (capped 250), `offset`; `page.total` is exact and the edge lists cover the current page |
 | `traverse` | Low-level walk of stored relation edges (`supersedes`, `annex_of`, `references`, `responds_to`, `belongs_to_thread`). | `entity_type`, `entity_id`, `limit` (capped 250), `offset`; the limit counts *visible* edges |
 | `list_matters` | Matters containing at least one version visible to the caller. | `limit` (capped 250), `offset`, `practice_area` (Area-of-Law node id, subtree semantics); the limit counts *visible* matters, and no `total` is reported |
@@ -159,17 +159,35 @@ text is stored as a SHA-256 fingerprint plus character count, never verbatim
 
 ### Downloads
 
-`download_document` never puts document bytes in model context by default.
-It issues a process-local capability token (`secrets.token_urlsafe(32)`,
-TTL 300 seconds) that freezes the document/version/source-object identity,
-content hash, and, critically, the caller's principals at issuance. The
-returned `ResourceLink` points at
+`download_document` answers two ways at once. The bytes ride back in the tool
+result as a base64 `BlobResourceContents` — that is the default, because an
+agent in a sandbox cannot reach the appliance over the network and a link is
+useless to it; pass `inline_blob=false` for the link alone.
+
+Beside the blob sits the link. The tool issues a process-local capability token
+(`secrets.token_urlsafe(32)`, TTL 300 seconds) that freezes the
+document/version/source-object identity, content hash, and, critically, the
+caller's principals at issuance. The returned `ResourceLink` points at
 `GET /api/downloads/{token}/{filename}`, alongside a ready-to-run `curl`
 command, the SHA-256, size, and MIME type. On every fetch the endpoint
 re-checks the ACL snapshot with the captured principals, so a revoked grant
 invalidates an unexpired link (the token is also revoked on failure: 404 for
 invalid/expired or no-longer-authorized, 410 for a missing blob). The fetch
 itself lands in the audit ledger attributed to the capability's principals.
+
+**The link is built for the caller, not for the appliance.** Its origin comes
+from `X-Forwarded-Proto` / `X-Forwarded-Host`, falling back to `Host`. A proxy
+that republishes `/mcp` — the hosted demo does, and so does any ingress in
+front of an appliance that is not itself on the network the client is on — owes
+the link two things, or it names a host the client cannot reach:
+
+- forward those headers on the MCP request, so the minted URL is the public one;
+- republish `GET /api/downloads/{token}/{filename}` to the appliance, and leave
+  it outside the session gate. The capability token is the whole credential:
+  it is issued only to a caller already authorized for that document version,
+  bound to the principals held then, expiring, and re-checked on every read. A
+  second gate adds nothing and breaks what the link is for — a `curl` from a
+  terminal and a fetch from a client that carries no session.
 
 ## The OAuth resource-server surface
 

--- a/docs/src/content/docs/product/external-access.md
+++ b/docs/src/content/docs/product/external-access.md
@@ -160,9 +160,18 @@ text is stored as a SHA-256 fingerprint plus character count, never verbatim
 ### Downloads
 
 `download_document` answers two ways at once. The bytes ride back in the tool
-result as a base64 `BlobResourceContents` — that is the default, because an
-agent in a sandbox cannot reach the appliance over the network and a link is
-useless to it; pass `inline_blob=false` for the link alone.
+result as a base64 `BlobResourceContents`, and `inline_blob` defaults to true,
+because an agent in a sandbox cannot reach the appliance over the network and a
+link is useless to it. Pass `inline_blob=false` for the link alone.
+
+**The blob is charged to whoever holds the result, and for a model that is
+context.** Base64 costs about four characters per three bytes, and a document
+original is not text a model can read — a `.docx` is a zip. Measured on the
+hosted demo, one 68 KB agreement: 2,592 bytes of result with `inline_blob=false`,
+95,702 with it true, or roughly 650 tokens against 24,000 for the same call.
+A caller that can fetch the link should pass `inline_blob=false` and fetch it;
+the default suits a client that will write the bytes out and has no route to the
+appliance.
 
 Beside the blob sits the link. The tool issues a process-local capability token
 (`secrets.token_urlsafe(32)`, TTL 300 seconds) that freezes the

--- a/docs/src/content/docs/product/external-access.md
+++ b/docs/src/content/docs/product/external-access.md
@@ -58,7 +58,7 @@ tool's name, short title, and tags.
 | `search_semantic` | Hybrid semantic + lexical search over chunks, ACL-filtered before ranking. | `query`, the same metadata filters, `limit` (default 8, capped 100), `offset` (see the ranked-window cap below) |
 | `get_document` | Reads one authorized document version, one page of chunks at a time. | `document_id`, `version_id`, `page` (default 1), `chunks_per_page` (default 12); returns a `page` block with `pages`, `first_chunk`, `last_chunk`, `total_chunks`, `has_more`, `next_page` |
 | `search_in_document` | Ranks one document's own passages against a query, for finding a clause without reading the file. | `document_id`, `query`, `version_id`, `limit` (default 5), `offset`; each result carries the chunk `ordinal` and the `get_document_page` that holds it |
-| `download_document` | Exports the exact original binary: the bytes in the result, plus a short-lived download link (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (default true; false returns the link alone) |
+| `download_document` | Exports the exact original binary: a short-lived download link, plus the bytes in the result when they are small (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (`true` always attaches the bytes, `false` never, unset while under 32 KB) |
 | `find_related_documents` | Stored relations plus labeled shared-thread and shared-matter context, with graph-ready edges. | `document_id`, `include_same_matter` (default true), `limit` (capped 250), `offset`; `page.total` is exact and the edge lists cover the current page |
 | `traverse` | Low-level walk of stored relation edges (`supersedes`, `annex_of`, `references`, `responds_to`, `belongs_to_thread`). | `entity_type`, `entity_id`, `limit` (capped 250), `offset`; the limit counts *visible* edges |
 | `list_matters` | Matters containing at least one version visible to the caller. | `limit` (capped 250), `offset`, `practice_area` (Area-of-Law node id, subtree semantics); the limit counts *visible* matters, and no `total` is reported |
@@ -159,19 +159,20 @@ text is stored as a SHA-256 fingerprint plus character count, never verbatim
 
 ### Downloads
 
-`download_document` answers two ways at once. The bytes ride back in the tool
-result as a base64 `BlobResourceContents`, and `inline_blob` defaults to true,
-because an agent in a sandbox cannot reach the appliance over the network and a
-link is useless to it. Pass `inline_blob=false` for the link alone.
+Every result carries the link. A small original *also* rides back as a base64
+`BlobResourceContents`, so a one-click export is a single round trip.
 
-**The blob is charged to whoever holds the result, and for a model that is
-context.** Base64 costs about four characters per three bytes, and a document
-original is not text a model can read — a `.docx` is a zip. Measured on the
-hosted demo, one 68 KB agreement: 2,592 bytes of result with `inline_blob=false`,
-95,702 with it true, or roughly 650 tokens against 24,000 for the same call.
-A caller that can fetch the link should pass `inline_blob=false` and fetch it;
-the default suits a client that will write the bytes out and has no route to the
-appliance.
+`inline_blob` decides that explicitly — `true` always attaches the bytes,
+`false` never does — and unset means "while they are small", currently under
+32 KB. The blob is charged to whoever holds the result, and for a model that is
+context spent on something it cannot read: base64 costs four characters per
+three bytes and a `.docx` is a zip. Measured on the hosted demo, one 68 KB
+agreement is 2,592 bytes of result without the blob and 95,702 with it, roughly
+650 tokens against 24,000 for the same call.
+
+Pass `true` if you will write the file out and cannot reach the appliance over
+the network — a sandboxed agent generally cannot, and that is what the bytes
+are there for.
 
 Beside the blob sits the link. The tool issues a process-local capability token
 (`secrets.token_urlsafe(32)`, TTL 300 seconds) that freezes the

--- a/integrations/agent-harness/legalmemory_mcp.py
+++ b/integrations/agent-harness/legalmemory_mcp.py
@@ -179,6 +179,13 @@ class McpBridge:
 
     def call(self, name: str, arguments: dict) -> str:
         self.call_counts[name] = self.call_counts.get(name, 0) + 1
+        if name == "download_document":
+            # Asked for here rather than left to the tool's own judgement, because
+            # this harness is the case the bytes exist for: _save_resources writes
+            # them to disk and the agent never holds them, so size costs nothing
+            # here, and the link the tool would otherwise hand back points at an
+            # appliance the sandbox cannot reach.
+            arguments = {**arguments, "inline_blob": True}
         result = self._post("tools/call", {"name": name, "arguments": arguments})
         blocks = result.get("content", [])
         texts = [b.get("text", "") for b in blocks if b.get("type") == "text"]

--- a/src/knowledge_index/mcp_server.py
+++ b/src/knowledge_index/mcp_server.py
@@ -70,6 +70,19 @@ def _with_filter(node: dict) -> dict:
     return {**node, "use_as_filter": _FACET_FILTER.get(facet)} if facet else node
 
 
+# How large an original may be before ``download_document`` stops volunteering the
+# bytes to a caller that did not ask for them either way.
+#
+# The blob is charged to whoever holds the result, and for a model that is context
+# spent on something it cannot read: base64 costs four characters per three bytes,
+# and a document original is not text (a .docx is a zip). Measured on the hosted
+# demo, one 68 KB agreement is 2.5 KB of result without the blob and 95 KB with it.
+# 32 KB is around 44 KB encoded, roughly 11k tokens — about as much as a tool
+# result should ever cost. Above it the caller gets the link, which is the answer
+# the tool gave everyone before the bytes were added.
+_INLINE_BLOB_AUTO_MAX_BYTES = 32 * 1024
+
+
 def _paged(page: Page, **extra) -> dict:
     """The response envelope every paginated tool returns."""
     return {"results": page.items, "page": page.as_dict(), **extra}
@@ -527,21 +540,23 @@ def create_mcp_server(
             "Download/export/copy one document into the current client workspace as the exact "
             "original Word, Excel, PDF, email, or other binary—never a text reconstruction. "
             "Call this whenever a task says download, save, copy, export, provide, or put a "
-            "document in the workspace. THE FILE COMES BACK IN THE RESULT: the bytes ride "
-            "along as a base64 BlobResourceContents, so write them out from there — you "
-            "already have the file and need to fetch nothing. A short-lived link and a curl "
-            "command come too, but they only work from a client that can reach this "
-            "appliance over the network, which a sandboxed agent generally cannot; treat "
-            "them as a fallback, never as the instruction. Pass inline_blob=false to get the "
-            "link alone when you truly do not want the bytes. The result includes SHA-256, "
-            "size, MIME type, filename, and exact citations."
+            "document in the workspace. Every result carries a short-lived download link "
+            "and a curl command; a small original ALSO rides along as a base64 "
+            "BlobResourceContents, so write it out from there rather than fetching it. "
+            "inline_blob decides that explicitly: TRUE always attaches the bytes — pass it "
+            "if you will write the file out and cannot reach this appliance over the "
+            "network, which a sandboxed agent generally cannot — and FALSE never does. "
+            "Left unset, the bytes come only when they are small enough to be worth "
+            "carrying; above that you get the link, because a base64 original is not "
+            "something you can read and costs you the context to hold. The result includes "
+            "SHA-256, size, MIME type, filename, and exact citations."
         )
     )
     def download_document(
         document_id: str,
         version_id: str | None = None,
         source_object_id: str | None = None,
-        inline_blob: bool = True,
+        inline_blob: bool | None = None,
         headers: dict[str, str] = CurrentHeaders(),
     ) -> ToolResult:
         with audited_call(
@@ -586,12 +601,18 @@ def create_mcp_server(
                 download_url = (
                     f"{base_url}/api/downloads/{capability.token}/{encoded_name}"
                 )
-                # The link is for a client that shares a network with the appliance.
-                # An agent in a sandbox does not. It will call this, run the curl
-                # below, get connection refused, and report — correctly from where
-                # it stands — that it could not deliver the files it was asked for.
-                # So the bytes ride back in the response by default and the command
-                # is offered as a fallback rather than as an instruction.
+                # Who carries the bytes. A client that will WRITE THE FILE OUT and
+                # cannot reach the appliance — an agent in a sandbox, which is what
+                # made the link alone insufficient — passes inline_blob=true and
+                # always gets them. A client that will fetch the link passes false.
+                # A caller that says nothing is usually a model, and for a model the
+                # blob is context spent on a base64 zip it cannot read, so it gets
+                # them only while they are small enough not to matter.
+                inline_blob = (
+                    downloadable.size_bytes <= _INLINE_BLOB_AUTO_MAX_BYTES
+                    if inline_blob is None
+                    else inline_blob
+                )
                 save_command = (
                     "curl --fail --location --output "
                     f"{shlex.quote(downloadable.filename)} {shlex.quote(download_url)}"
@@ -614,7 +635,11 @@ def create_mcp_server(
                                 "The file itself is attached to this result as a "
                                 "base64 blob — write it out from there. "
                                 if inline_blob
-                                else ""
+                                else "The bytes are not attached: this original is "
+                                "larger than is worth carrying in a result. Fetch it "
+                                "with the command below, or call again with "
+                                "inline_blob=true if you cannot reach this appliance "
+                                "and will write the file out yourself. "
                             )
                             + "If your client can reach this appliance directly, "
                             f"this also works:\n{save_command}"

--- a/tests/test_mcp_citations.py
+++ b/tests/test_mcp_citations.py
@@ -693,3 +693,55 @@ def test_mcp_download_returns_exact_original_blob_and_short_lived_workspace_link
         resource = next(block["resource"] for block in inline["content"] if block["type"] == "resource")
         assert base64.b64decode(resource["blob"]) == original
         assert hashlib.sha256(original).hexdigest() == content_hash
+
+
+def test_mcp_download_link_names_the_origin_the_caller_reached(factory, tmp_path) -> None:
+    """The link and the curl are built for the caller, not for the appliance.
+
+    A client that reaches the appliance through a proxy — the hosted demo
+    republishing ``/mcp``, an ingress, anything terminating TLS — is answered by
+    a process whose own Host is a container address. Building the download URL
+    from that Host hands every such client a link to a host that does not exist
+    where they stand, which is how the link path came to be unusable while the
+    inline blob kept working. The forwarded origin is what the caller can
+    actually reach, so it is what the link has to name.
+    """
+
+    artifact_dir = tmp_path / "artifacts"
+    with factory() as session:
+        original, _ = _seed_downloadable_pair(session, artifact_dir)
+
+    store = ConfigStore(tmp_path / "config.json")
+    store.save(_header_auth_config(artifact_dir))
+    with TestClient(create_app(factory, store)) as client:
+        metadata = client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "download",
+                "method": "tools/call",
+                "params": {
+                    "name": "download_document",
+                    "arguments": {"document_id": "download-document"},
+                },
+            },
+            headers={
+                "accept": "application/json, text/event-stream",
+                "x-ki-principals": "group:citation-test",
+                "x-forwarded-host": "legalmemory.example",
+                "x-forwarded-proto": "https",
+            },
+        ).json()["result"]["structuredContent"]
+
+        assert metadata["download_url"].startswith(
+            "https://legalmemory.example/api/downloads/"
+        )
+        # The curl a caller is invited to run carries the same origin: a link
+        # that is right and a command that is wrong is the same outage.
+        assert "https://legalmemory.example/api/downloads/" in metadata["save_command"]
+
+        # The path still resolves on the appliance itself, which is what lets a
+        # proxy re-base it onto its own origin and serve the bytes.
+        served = client.get(urlsplit(metadata["download_url"]).path)
+        assert served.status_code == 200
+        assert served.content == original

--- a/tests/test_mcp_citations.py
+++ b/tests/test_mcp_citations.py
@@ -159,8 +159,16 @@ def _seed_cited_document(session: Session) -> dict[str, object]:
     }
 
 
-def _seed_downloadable_pair(session: Session, artifact_dir) -> tuple[bytes, str]:
-    original = b"PK\x03\x04exact-original-docx-bytes"
+def _seed_downloadable_pair(
+    session: Session, artifact_dir, original: bytes | None = None
+) -> tuple[bytes, str]:
+    """Seed one downloadable document plus a related one.
+
+    ``original`` overrides the root document's bytes, for the tests that turn on
+    how large it is. The related document stays small either way.
+    """
+
+    original = b"PK\x03\x04exact-original-docx-bytes" if original is None else original
     related_original = b"PK\x03\x04related-original-docx-bytes"
     stored = LocalArtifactStore(artifact_dir).put_blob(
         BytesIO(original), max_bytes=1024 * 1024
@@ -745,3 +753,66 @@ def test_mcp_download_link_names_the_origin_the_caller_reached(factory, tmp_path
         served = client.get(urlsplit(metadata["download_url"]).path)
         assert served.status_code == 200
         assert served.content == original
+
+
+def test_mcp_download_volunteers_the_bytes_only_while_they_are_small(
+    factory, tmp_path
+) -> None:
+    """A caller that says nothing about the blob is not handed a large one.
+
+    ``inline_blob`` unset means the tool decides, and it decides on size: the
+    result is usually read by a model, where a base64 original is context spent
+    on something it cannot read. A caller that will write the file out and
+    cannot reach the appliance still asks for the bytes explicitly and still
+    gets them, whatever the size.
+    """
+
+    artifact_dir = tmp_path / "artifacts"
+    with factory() as session:
+        # Comfortably past the threshold, so the default has to choose the link.
+        original, _ = _seed_downloadable_pair(
+            session, artifact_dir, original=b"PK\x03\x04" + b"x" * (64 * 1024)
+        )
+
+    store = ConfigStore(tmp_path / "config.json")
+    store.save(_header_auth_config(artifact_dir))
+    headers = {
+        "accept": "application/json, text/event-stream",
+        "x-ki-principals": "group:citation-test",
+    }
+
+    def download(arguments: dict) -> dict:
+        return client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "download",
+                "method": "tools/call",
+                "params": {"name": "download_document", "arguments": arguments},
+            },
+            headers=headers,
+        ).json()["result"]
+
+    def blobs(result: dict) -> list[dict]:
+        return [block for block in result["content"] if block["type"] == "resource"]
+
+    with TestClient(create_app(factory, store)) as client:
+        # Unset: the link, and the link alone.
+        unset = download({"document_id": "download-document"})
+        assert blobs(unset) == []
+        assert unset["structuredContent"]["delivery"] == "resource_link"
+        # Still a complete answer — the bytes are one fetch away, and the text
+        # says so rather than leaving a caller to conclude there is no file.
+        assert any(block["type"] == "resource_link" for block in unset["content"])
+        assert "inline_blob=true" in unset["content"][0]["text"]
+
+        # Explicit: the bytes, exactly as before, size notwithstanding.
+        asked = download({"document_id": "download-document", "inline_blob": True})
+        assert base64.b64decode(blobs(asked)[0]["resource"]["blob"]) == original
+        assert asked["structuredContent"]["delivery"] == "embedded_blob"
+
+        # A small original still comes back whole without being asked for, which
+        # is what keeps a one-click export a single round trip.
+        small = download({"document_id": "related-document"})
+        assert blobs(small), "a small original should not cost the caller a fetch"
+        assert small["structuredContent"]["delivery"] == "embedded_blob"


### PR DESCRIPTION
Two faults on the same tool, found chasing a LegalWork report.

**The bytes.** `inline_blob` defaulted to true, so every caller that did not name
it got the whole file base64-encoded. Most callers are models, and for a model
that is context spent on something it cannot read — a `.docx` is a zip. Same
document on the hosted demo: 2,592 B of result with the blob off, 95,702 B with
it on, roughly 650 tokens against 24,000.

**The link.** The other half of the answer was unusable anyway: through the
demo's `/mcp` proxy the appliance minted a `download_url` naming
`http://127.0.0.1:8000`, its own address, which nothing outside the container
network can reach.

## Changes

- `inline_blob` is three-state: `true` always attaches the bytes, `false` never,
  unset attaches them while the original is under 32 KB. Above it the text names
  both ways to get the file, so a link-only answer cannot read as "no file".
- Callers that need bytes now say so: the agent harness passes `true` (it writes
  them to disk and the model never holds them), the demo's preview passes
  `false` (it only ever used the capability path and was discarding a base64
  copy every click).
- The `/mcp` proxy forwards the caller's origin, so the appliance mints a public
  link; `GET /api/downloads/{token}/{filename}` is republished, re-based onto the
  appliance the way `/api/preview` already does.
- That path stays outside the session gate: the capability token is the
  credential (300s TTL, ACL re-checked per read, revoked on failure), and a gate
  breaks the `curl` the link exists for.

## Verified

Against a real appliance and a real demo instance: the printed `save_command`
runs verbatim and lands the exact original, SHA-256 matching; a large original
unset returns the link alone and with `inline_blob=true` returns the bytes; a
small one still comes back whole. Demo pages, `/api/tree`, `/api/preview` and
`/api/document-text` all still serve. The demo's chat never exposed
`download_document` to its model, so it is untouched.