### PR TITLE
Attach the original's bytes only when they are small, or when asked

### DIFF
--- a/demo/src/app/api/preview/route.ts
+++ b/demo/src/app/api/preview/route.ts
@@ -23,6 +23,9 @@ export async function GET(request: Request) {
       document_id: documentId,
       version_id: url.searchParams.get("version_id") ?? undefined,
       source_object_id: url.searchParams.get("source_object_id") ?? undefined,
+      // Only the capability path below is used, so the base64 copy of the same
+      // bytes would be built, sent and thrown away on every preview click.
+      inline_blob: false,
     });
 
     const meta = (result.structuredContent ?? {}) as {

--- a/docs/src/content/docs/product/external-access.md
+++ b/docs/src/content/docs/product/external-access.md
@@ -58,7 +58,7 @@ tool's name, short title, and tags.
 | `search_semantic` | Hybrid semantic + lexical search over chunks, ACL-filtered before ranking. | `query`, the same metadata filters, `limit` (default 8, capped 100), `offset` (see the ranked-window cap below) |
 | `get_document` | Reads one authorized document version, one page of chunks at a time. | `document_id`, `version_id`, `page` (default 1), `chunks_per_page` (default 12); returns a `page` block with `pages`, `first_chunk`, `last_chunk`, `total_chunks`, `has_more`, `next_page` |
 | `search_in_document` | Ranks one document's own passages against a query, for finding a clause without reading the file. | `document_id`, `query`, `version_id`, `limit` (default 5), `offset`; each result carries the chunk `ordinal` and the `get_document_page` that holds it |
-| `download_document` | Exports the exact original binary: the bytes in the result, plus a short-lived download link (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (default true; false returns the link alone) |
+| `download_document` | Exports the exact original binary: a short-lived download link, plus the bytes in the result when they are small (see below). | `document_id`, `version_id`, `source_object_id`, `inline_blob` (`true` always attaches the bytes, `false` never, unset while under 32 KB) |
 | `find_related_documents` | Stored relations plus labeled shared-thread and shared-matter context, with graph-ready edges. | `document_id`, `include_same_matter` (default true), `limit` (capped 250), `offset`; `page.total` is exact and the edge lists cover the current page |
 | `traverse` | Low-level walk of stored relation edges (`supersedes`, `annex_of`, `references`, `responds_to`, `belongs_to_thread`). | `entity_type`, `entity_id`, `limit` (capped 250), `offset`; the limit counts *visible* edges |
 | `list_matters` | Matters containing at least one version visible to the caller. | `limit` (capped 250), `offset`, `practice_area` (Area-of-Law node id, subtree semantics); the limit counts *visible* matters, and no `total` is reported |
@@ -159,19 +159,20 @@ text is stored as a SHA-256 fingerprint plus character count, never verbatim
 
 ### Downloads
 
-`download_document` answers two ways at once. The bytes ride back in the tool
-result as a base64 `BlobResourceContents`, and `inline_blob` defaults to true,
-because an agent in a sandbox cannot reach the appliance over the network and a
-link is useless to it. Pass `inline_blob=false` for the link alone.
+Every result carries the link. A small original *also* rides back as a base64
+`BlobResourceContents`, so a one-click export is a single round trip.
 
-**The blob is charged to whoever holds the result, and for a model that is
-context.** Base64 costs about four characters per three bytes, and a document
-original is not text a model can read — a `.docx` is a zip. Measured on the
-hosted demo, one 68 KB agreement: 2,592 bytes of result with `inline_blob=false`,
-95,702 with it true, or roughly 650 tokens against 24,000 for the same call.
-A caller that can fetch the link should pass `inline_blob=false` and fetch it;
-the default suits a client that will write the bytes out and has no route to the
-appliance.
+`inline_blob` decides that explicitly — `true` always attaches the bytes,
+`false` never does — and unset means "while they are small", currently under
+32 KB. The blob is charged to whoever holds the result, and for a model that is
+context spent on something it cannot read: base64 costs four characters per
+three bytes and a `.docx` is a zip. Measured on the hosted demo, one 68 KB
+agreement is 2,592 bytes of result without the blob and 95,702 with it, roughly
+650 tokens against 24,000 for the same call.
+
+Pass `true` if you will write the file out and cannot reach the appliance over
+the network — a sandboxed agent generally cannot, and that is what the bytes
+are there for.
 
 Beside the blob sits the link. The tool issues a process-local capability token
 (`secrets.token_urlsafe(32)`, TTL 300 seconds) that freezes the

--- a/integrations/agent-harness/legalmemory_mcp.py
+++ b/integrations/agent-harness/legalmemory_mcp.py
@@ -179,6 +179,13 @@ class McpBridge:
 
     def call(self, name: str, arguments: dict) -> str:
         self.call_counts[name] = self.call_counts.get(name, 0) + 1
+        if name == "download_document":
+            # Asked for here rather than left to the tool's own judgement, because
+            # this harness is the case the bytes exist for: _save_resources writes
+            # them to disk and the agent never holds them, so size costs nothing
+            # here, and the link the tool would otherwise hand back points at an
+            # appliance the sandbox cannot reach.
+            arguments = {**arguments, "inline_blob": True}
         result = self._post("tools/call", {"name": name, "arguments": arguments})
         blocks = result.get("content", [])
         texts = [b.get("text", "") for b in blocks if b.get("type") == "text"]

--- a/src/knowledge_index/mcp_server.py
+++ b/src/knowledge_index/mcp_server.py
@@ -70,6 +70,19 @@ def _with_filter(node: dict) -> dict:
     return {**node, "use_as_filter": _FACET_FILTER.get(facet)} if facet else node
 
 
+# How large an original may be before ``download_document`` stops volunteering the
+# bytes to a caller that did not ask for them either way.
+#
+# The blob is charged to whoever holds the result, and for a model that is context
+# spent on something it cannot read: base64 costs four characters per three bytes,
+# and a document original is not text (a .docx is a zip). Measured on the hosted
+# demo, one 68 KB agreement is 2.5 KB of result without the blob and 95 KB with it.
+# 32 KB is around 44 KB encoded, roughly 11k tokens — about as much as a tool
+# result should ever cost. Above it the caller gets the link, which is the answer
+# the tool gave everyone before the bytes were added.
+_INLINE_BLOB_AUTO_MAX_BYTES = 32 * 1024
+
+
 def _paged(page: Page, **extra) -> dict:
     """The response envelope every paginated tool returns."""
     return {"results": page.items, "page": page.as_dict(), **extra}
@@ -527,21 +540,23 @@ def create_mcp_server(
             "Download/export/copy one document into the current client workspace as the exact "
             "original Word, Excel, PDF, email, or other binary—never a text reconstruction. "
             "Call this whenever a task says download, save, copy, export, provide, or put a "
-            "document in the workspace. THE FILE COMES BACK IN THE RESULT: the bytes ride "
-            "along as a base64 BlobResourceContents, so write them out from there — you "
-            "already have the file and need to fetch nothing. A short-lived link and a curl "
-            "command come too, but they only work from a client that can reach this "
-            "appliance over the network, which a sandboxed agent generally cannot; treat "
-            "them as a fallback, never as the instruction. Pass inline_blob=false to get the "
-            "link alone when you truly do not want the bytes. The result includes SHA-256, "
-            "size, MIME type, filename, and exact citations."
+            "document in the workspace. Every result carries a short-lived download link "
+            "and a curl command; a small original ALSO rides along as a base64 "
+            "BlobResourceContents, so write it out from there rather than fetching it. "
+            "inline_blob decides that explicitly: TRUE always attaches the bytes — pass it "
+            "if you will write the file out and cannot reach this appliance over the "
+            "network, which a sandboxed agent generally cannot — and FALSE never does. "
+            "Left unset, the bytes come only when they are small enough to be worth "
+            "carrying; above that you get the link, because a base64 original is not "
+            "something you can read and costs you the context to hold. The result includes "
+            "SHA-256, size, MIME type, filename, and exact citations."
         )
     )
     def download_document(
         document_id: str,
         version_id: str | None = None,
         source_object_id: str | None = None,
-        inline_blob: bool = True,
+        inline_blob: bool | None = None,
         headers: dict[str, str] = CurrentHeaders(),
     ) -> ToolResult:
         with audited_call(
@@ -586,12 +601,18 @@ def create_mcp_server(
                 download_url = (
                     f"{base_url}/api/downloads/{capability.token}/{encoded_name}"
                 )
-                # The link is for a client that shares a network with the appliance.
-                # An agent in a sandbox does not. It will call this, run the curl
-                # below, get connection refused, and report — correctly from where
-                # it stands — that it could not deliver the files it was asked for.
-                # So the bytes ride back in the response by default and the command
-                # is offered as a fallback rather than as an instruction.
+                # Who carries the bytes. A client that will WRITE THE FILE OUT and
+                # cannot reach the appliance — an agent in a sandbox, which is what
+                # made the link alone insufficient — passes inline_blob=true and
+                # always gets them. A client that will fetch the link passes false.
+                # A caller that says nothing is usually a model, and for a model the
+                # blob is context spent on a base64 zip it cannot read, so it gets
+                # them only while they are small enough not to matter.
+                inline_blob = (
+                    downloadable.size_bytes <= _INLINE_BLOB_AUTO_MAX_BYTES
+                    if inline_blob is None
+                    else inline_blob
+                )
                 save_command = (
                     "curl --fail --location --output "
                     f"{shlex.quote(downloadable.filename)} {shlex.quote(download_url)}"
@@ -614,7 +635,11 @@ def create_mcp_server(
                                 "The file itself is attached to this result as a "
                                 "base64 blob — write it out from there. "
                                 if inline_blob
-                                else ""
+                                else "The bytes are not attached: this original is "
+                                "larger than is worth carrying in a result. Fetch it "
+                                "with the command below, or call again with "
+                                "inline_blob=true if you cannot reach this appliance "
+                                "and will write the file out yourself. "
                             )
                             + "If your client can reach this appliance directly, "
                             f"this also works:\n{save_command}"

--- a/tests/test_mcp_citations.py
+++ b/tests/test_mcp_citations.py
@@ -159,8 +159,16 @@ def _seed_cited_document(session: Session) -> dict[str, object]:
     }
 
 
-def _seed_downloadable_pair(session: Session, artifact_dir) -> tuple[bytes, str]:
-    original = b"PK\x03\x04exact-original-docx-bytes"
+def _seed_downloadable_pair(
+    session: Session, artifact_dir, original: bytes | None = None
+) -> tuple[bytes, str]:
+    """Seed one downloadable document plus a related one.
+
+    ``original`` overrides the root document's bytes, for the tests that turn on
+    how large it is. The related document stays small either way.
+    """
+
+    original = b"PK\x03\x04exact-original-docx-bytes" if original is None else original
     related_original = b"PK\x03\x04related-original-docx-bytes"
     stored = LocalArtifactStore(artifact_dir).put_blob(
         BytesIO(original), max_bytes=1024 * 1024
@@ -745,3 +753,66 @@ def test_mcp_download_link_names_the_origin_the_caller_reached(factory, tmp_path
         served = client.get(urlsplit(metadata["download_url"]).path)
         assert served.status_code == 200
         assert served.content == original
+
+
+def test_mcp_download_volunteers_the_bytes_only_while_they_are_small(
+    factory, tmp_path
+) -> None:
+    """A caller that says nothing about the blob is not handed a large one.
+
+    ``inline_blob`` unset means the tool decides, and it decides on size: the
+    result is usually read by a model, where a base64 original is context spent
+    on something it cannot read. A caller that will write the file out and
+    cannot reach the appliance still asks for the bytes explicitly and still
+    gets them, whatever the size.
+    """
+
+    artifact_dir = tmp_path / "artifacts"
+    with factory() as session:
+        # Comfortably past the threshold, so the default has to choose the link.
+        original, _ = _seed_downloadable_pair(
+            session, artifact_dir, original=b"PK\x03\x04" + b"x" * (64 * 1024)
+        )
+
+    store = ConfigStore(tmp_path / "config.json")
+    store.save(_header_auth_config(artifact_dir))
+    headers = {
+        "accept": "application/json, text/event-stream",
+        "x-ki-principals": "group:citation-test",
+    }
+
+    def download(arguments: dict) -> dict:
+        return client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "download",
+                "method": "tools/call",
+                "params": {"name": "download_document", "arguments": arguments},
+            },
+            headers=headers,
+        ).json()["result"]
+
+    def blobs(result: dict) -> list[dict]:
+        return [block for block in result["content"] if block["type"] == "resource"]
+
+    with TestClient(create_app(factory, store)) as client:
+        # Unset: the link, and the link alone.
+        unset = download({"document_id": "download-document"})
+        assert blobs(unset) == []
+        assert unset["structuredContent"]["delivery"] == "resource_link"
+        # Still a complete answer — the bytes are one fetch away, and the text
+        # says so rather than leaving a caller to conclude there is no file.
+        assert any(block["type"] == "resource_link" for block in unset["content"])
+        assert "inline_blob=true" in unset["content"][0]["text"]
+
+        # Explicit: the bytes, exactly as before, size notwithstanding.
+        asked = download({"document_id": "download-document", "inline_blob": True})
+        assert base64.b64decode(blobs(asked)[0]["resource"]["blob"]) == original
+        assert asked["structuredContent"]["delivery"] == "embedded_blob"
+
+        # A small original still comes back whole without being asked for, which
+        # is what keeps a one-click export a single round trip.
+        small = download({"document_id": "related-document"})
+        assert blobs(small), "a small original should not cost the caller a fetch"
+        assert small["structuredContent"]["delivery"] == "embedded_blob"


### PR DESCRIPTION
`inline_blob` defaulted to true, so every caller that did not name it got the
whole file base64-encoded. Most callers are models, and for a model that is
context spent on something it cannot read: a `.docx` is a zip.

Same document on the hosted demo:

| `inline_blob` | result | ≈ tokens |
| --- | --- | --- |
| `false` | 2,592 B | 650 |
| `true` | 95,702 B | 24,000 |

The parameter is now three-state: `true` always attaches the bytes, `false`
never, unset attaches them while the original is under 32 KB. Clients that need
bytes ask for them — the agent harness writes them to disk and never shows the
model, so it passes `true`; the demo's preview only used the capability path, so
it passes `false` and stops building a base64 copy it discards every click.

Above the threshold the text names both ways to get the file, so a link-only
answer cannot read as "there is no file".

Stacked on #18 — the link has to be reachable before it is a fair answer.