### PR TITLE
demo: let the chat answer for the product, from the docs it already ships

### DIFF
--- a/demo/src/app/api/chat/route.ts
+++ b/demo/src/app/api/chat/route.ts
@@ -1,7 +1,9 @@
-import { convertToModelMessages, stepCountIs, streamText, type UIMessage } from "ai";
+import { convertToModelMessages, stepCountIs, streamText, tool, type UIMessage } from "ai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { z } from "zod";
 
 import { CHAT_TOOL_SCHEMAS, openMcpClient } from "@/lib/mcp";
+import { searchProductDocs } from "@/lib/product-docs";
 
 // An estate-wide enumeration runs many tool calls before it can answer; 120s
 // cut those off mid-sweep, which is the same truncation as a low step budget
@@ -25,7 +27,20 @@ function model() {
   return gateway(process.env.DEMO_MODEL ?? "gemini-3.6-flash");
 }
 
-const SYSTEM_PROMPT = `You are the LegalMemory demo assistant. You answer questions about the documents indexed in this firm's LegalMemory appliance, and about nothing else.
+const SYSTEM_PROMPT = `You are the LegalMemory demo assistant. You do two things, and nothing else: you answer questions about the documents indexed in this appliance, and you answer questions about LegalMemory itself from its documentation.
+
+## What you are
+
+You are a demonstration of LegalMemory running on a sample corpus — a fictional firm's files. You are not LegalMemory, and you are not this reader's own deployment. That distinction matters when someone asks for something you cannot do: the honest answer is usually "the product does this; this demo does not expose it", not "I cannot".
+
+What this demo deliberately leaves out, and what a real deployment has:
+
+- **It is read-only.** It finds, reads and cites. It does not draft, edit, redline or generate documents, and it cannot export or bundle files for download. Drafting from a firm's own precedent is a thing LegalMemory is built around; it is not wired up here.
+- **It is signed in as one fixed identity**, so every visitor sees the same estate. Access control is the part of the product that decides what a given lawyer may retrieve — compiled into the query before it runs — and this demo cannot show it, because there is only one user.
+- **The corpus is fixed sample data.** No connector is running, nothing is being ingested, and these are not anyone's real matters.
+- **It offers a subset of the appliance's tools**, chosen for this demo.
+
+Say which of these applies when it is the reason you are declining. Do not apologise for the product; state the boundary and offer the docs.
 
 ## What you can do
 
@@ -40,6 +55,9 @@ Every fact you state about a document must come from a tool call in this convers
 - list_matter_documents — EVERY document in one matter, complete and unpaged. The folder view. Call it before deciding a matter lacks something: a page of search hits is a sample, and a document filed under a title your query did not use is invisible to ranking.
 - list_firm_people — the firm's own lawyers, and the directory behind the practice_group and firm_person filters. Use it to learn what a group is actually called before filtering on it.
 - list_taxonomies — the practice-area, document-type and task-type trees. Use it to turn a practice area's name into the node id that search_filter, search_semantic and list_matters take.
+- search_product_docs — LegalMemory's own documentation: what it is, how retrieval and access control work, which systems it connects to (SharePoint, OneDrive, Google Drive, Dropbox, **Clio**, local folders), how it is deployed, what it costs to run, how MCP and the API work. This is the *product*, not the firm's files. Use it for every question about what LegalMemory is or does, including integration questions, and never answer such a question from memory. It is lexical search: query it with the terms the docs would use ("Clio connector", "access control"), not a whole sentence, and try a second phrasing before concluding the docs are silent.
+
+Those two sets never mix. A question about the firm's matters is never answered from the product docs, and a claim about what LegalMemory can do is never answered from the firm's documents or from your own knowledge. Cite a docs page by linking its URL; do not use the [[doc:...]] citation form for it, which is for the firm's documents alone.
 
 Every list-shaped tool returns \`{results, page}\`, not a bare list. \`page.has_more: true\` means more matched than you were shown; the next page is the same call with \`offset: page.next_offset\`. A full page is a sample, not an inventory — so before you say "all", "every", "none", "only", or give a count, either page until \`has_more\` is false or say which part of the set you looked at.
 
@@ -101,7 +119,9 @@ Write with the citations inline, the way you would in a memo. Structure the answ
 
 ## What you must decline
 
-You answer questions about the indexed documents. If asked for something else — general legal advice, drafting, world knowledge, arithmetic, code, opinions, anything not grounded in these files — decline in one short, courteous sentence and say what you can help with instead. Do not answer partly and then decline. Do not apologise at length.
+You answer questions about the indexed documents, and questions about LegalMemory from its docs. If asked for something else — general legal advice, world knowledge, arithmetic, code, opinions, anything grounded in neither — decline in one short, courteous sentence and say what you can help with instead. Do not answer partly and then decline. Do not apologise at length.
+
+Declining is not the same as denying the capability. When someone asks you to draft, edit or export, they are asking for something this demo does not do — say so in one line, say whether LegalMemory itself addresses it (search_product_docs before you claim either way), and then give them what you *can*: the precedents in the estate that answer the question behind the request. Someone who asks for a draft agreement usually wants the firm's best precedent for it, and that you can find.
 
 Legal questions that a document in the estate would answer are in scope; legal questions in general are not. "What did we agree on indemnities in the Chow matter" is your work. "What is the statute of limitations in Delaware" is not, unless a document here says so — and then you cite the document, not the law.
 
@@ -152,7 +172,30 @@ export async function POST(request: Request) {
       // first so a client cannot relax them by prepending its own.
       system: system ? `${SYSTEM_PROMPT}\n\n${system}` : SYSTEM_PROMPT,
       messages: await convertToModelMessages(messages),
-      tools: await mcp.tools({ schemas: CHAT_TOOL_SCHEMAS }),
+      tools: {
+        ...(await mcp.tools({ schemas: CHAT_TOOL_SCHEMAS })),
+        search_product_docs: tool({
+          description:
+            "Search LegalMemory's own documentation: what the product is, how retrieval and " +
+            "access control work, which systems it connects to (SharePoint, OneDrive, Google " +
+            "Drive, Dropbox, Clio, local folders), deployment, cost, MCP and the API. This is " +
+            "the product, not the firm's documents. Lexical search — use the terms the docs " +
+            "would use, not a full sentence.",
+          inputSchema: z.object({
+            query: z.string().describe("Keywords, e.g. 'Clio connector' or 'access control'."),
+            limit: z.number().int().min(1).max(5).optional().describe("Pages to return; default 3."),
+          }),
+          execute: async ({ query, limit }) => {
+            try {
+              const pages = await searchProductDocs(query, limit ?? 3);
+              if (!pages.length) return { results: [], note: "No documentation page matched." };
+              return { results: pages };
+            } catch {
+              return { results: [], note: "The documentation index is unavailable." };
+            }
+          },
+        }),
+      },
       // An estate-wide enumeration ("every matter where…", "how many of our…")
       // legitimately spends dozens of steps: sweep for candidates from several
       // angles, then read a document per candidate to verify it. An answer that

--- a/demo/src/lib/product-docs.ts
+++ b/demo/src/lib/product-docs.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+// Reads the Pagefind index the docs build already ships at /docs/pagefind/.
+
+const DOCS_DIR =
+  process.env.DOCS_DIR ??
+  (existsSync(join(process.cwd(), "..", "docs", "dist"))
+    ? join(process.cwd(), "..", "docs", "dist")
+    : "/srv/docs");
+
+// Pagefind fetches its index shards; Node's fetch refuses file: URLs.
+let fetchPatched = false;
+function allowFileFetch() {
+  if (fetchPatched) return;
+  fetchPatched = true;
+  const real = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (!url.startsWith("file://")) return real(input, init);
+    try {
+      return new Response(new Uint8Array(await readFile(fileURLToPath(url))), { status: 200 });
+    } catch {
+      return new Response(null, { status: 404 });
+    }
+  };
+}
+
+type PagefindModule = {
+  options: (opts: Record<string, unknown>) => Promise<void> | void;
+  init: () => Promise<void>;
+  search: (query: string) => Promise<{ results: Array<{ data: () => Promise<RawResult> }> }>;
+};
+
+type RawResult = {
+  url: string;
+  content?: string;
+  meta?: { title?: string };
+  sub_results?: Array<{ title?: string }>;
+};
+
+let pagefind: Promise<PagefindModule> | null = null;
+
+function load(): Promise<PagefindModule> {
+  if (pagefind) return pagefind;
+  pagefind = (async () => {
+    allowFileFetch();
+    const entry = join(DOCS_DIR, "pagefind", "pagefind.js");
+    if (!existsSync(entry)) throw new Error(`Pagefind index not found at ${entry}`);
+    const mod = (await import(
+      /* webpackIgnore: true */ pathToFileURL(entry).href
+    )) as PagefindModule;
+    await mod.options({ basePath: pathToFileURL(join(DOCS_DIR, "pagefind") + "/").href });
+    await mod.init();
+    return mod;
+  })();
+  pagefind.catch(() => {
+    pagefind = null;
+  });
+  return pagefind;
+}
+
+// With a file: basePath Pagefind returns a filesystem path; the public path is
+// the part from /docs/ onward.
+function publicPath(url: string): string {
+  let path = url.replace(/^\/?file:\/*/, "/");
+  const marker = path.indexOf("/docs/");
+  if (marker >= 0) return path.slice(marker);
+  if (path.startsWith(DOCS_DIR)) path = path.slice(DOCS_DIR.length);
+  return "/docs" + (path.startsWith("/") ? path : `/${path}`);
+}
+
+export interface ProductDocResult {
+  title: string;
+  url: string;
+  content: string;
+  sections: string[];
+}
+
+export async function searchProductDocs(query: string, limit = 3): Promise<ProductDocResult[]> {
+  const mod = await load();
+  const found = await mod.search(query);
+  const top = found.results.slice(0, Math.max(1, Math.min(limit, 5)));
+  const pages = await Promise.all(top.map((r) => r.data()));
+  return pages.map((page) => ({
+    title: page.meta?.title ?? "Untitled",
+    url: publicPath(page.url),
+    content: page.content ?? "",
+    sections: (page.sub_results ?? [])
+      .map((s) => s.title)
+      .filter((t): t is string => Boolean(t)),
+  }));
+}

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -111,6 +111,10 @@ services:
       # Behind the edge the demo cannot see its own public name, and OAuth
       # discovery has to publish one that clients can actually reach.
       DEMO_PUBLIC_URL: https://${DEMO_DOMAIN}
+      DOCS_DIR: /srv/docs
+    volumes:
+      # The same build Caddy serves at /docs, for the chat's docs search.
+      - docs_dist:/srv/docs:ro
 
 volumes:
   docs_dist:


### PR DESCRIPTION
## Why

Three visitors in ten days asked the demo what LegalMemory is and how it integrates. One of them uses **Clio** — which has a connector and a documentation page — and got:

> I do not have technical information regarding specific third-party integrations with Clio.

That was the prompt working as written: it said the assistant answers about indexed documents *"and about nothing else"*. Two of the three were the most engaged visitors in the window.

## What

**`search_product_docs`** — reads the Pagefind index the docs build already produces and Caddy already serves at `/docs/pagefind/`. The `docs_dist` volume is mounted read-only into the demo, so it is the same artifact, read off disk rather than fetched back over the public URL.

No second index and no catalog: every page already carries `title` and `description`, Pagefind is already built, and a parallel index would be one more thing to keep in step. Pagefind returns the full page text, so one tool covers search and read.

**The prompt** gained a "What you are" section: this is a demo on sample data, not the product and not the reader's deployment. It is read-only, signed in as one fixed identity, on a fixed corpus, with a subset of the tools. Asked to draft or export, it now names the boundary, checks the docs before claiming the product can or cannot, and offers the precedents behind the request — someone asking for a draft agreement usually wants the firm's best precedent for it.

The two lanes are kept apart explicitly: firm questions are never answered from product docs, product claims never from the firm's files or from memory, and docs pages link rather than using the `[[doc:...]]` citation form.

## Notes

- Local `npm run dev` falls back to `../docs/dist`; where the index is absent the tool reports it and the model says so.
- Page content is returned whole — no truncation.
- `tsc --noEmit` and `eslint` clean; search verified against both the deployed index and a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)